### PR TITLE
Embed SourceLink in symbols

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,5 +4,6 @@ build_script:
   - ps: .\build-utils\Build.ps1
 artifacts:
   - path: '**\*.nupkg'
+  - path: '**\*.snupkg'
 test_script:
   - ps: .\build-utils\Test.ps1 -Logger Appveyor

--- a/src/Couchbase.EntityFramework/Couchbase.EntityFramework.csproj
+++ b/src/Couchbase.EntityFramework/Couchbase.EntityFramework.csproj
@@ -1,11 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Motivation
----------
Provide an easy debugging experience for consumers of the package.

Modifications
-------------
Add the Microsoft.SourceLink.GitHub project as a private asset.

Dual-target .NET 4.6.1 and .NET Standard 2.0 (as per Microsoft
recommendations for new packages https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting).

Collect snupkg files as artifacts.

Results
-------
Symbols are generated in a separate snupkg file, with SourceLink data
embedded. These symbols can be uploaded to NuGet.org along with the main
package. Users can follow
[these instructions](https://blog.nuget.org/20181116/Improved-debugging-experience-with-the-NuGet-org-symbol-server-and-snupkg.html)
to debug (requires VS 15.9 or later).

Fixes #3 