### PR TITLE
Port Relinq portions of Linq2Couchbase

### DIFF
--- a/src/Couchbase.EntityFramework/BucketQueryOptions.cs
+++ b/src/Couchbase.EntityFramework/BucketQueryOptions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Couchbase.EntityFramework.Filters;
+using Couchbase.Linq;
+
+namespace Couchbase.EntityFramework
+{
+    /// <summary>
+    /// Options to control queries against an <see cref="IBucketContext"/>.
+    /// </summary>
+    [Flags]
+    public enum BucketQueryOptions
+    {
+        /// <summary>
+        /// No special options, use default behavior.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Supress all registered filters in the <see cref="DocumentFilterManager"/>.
+        /// </summary>
+        SuppressFilters = 1
+    }
+}

--- a/src/Couchbase.EntityFramework/Class1.cs
+++ b/src/Couchbase.EntityFramework/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace Couchbase.EntityFramework
-{
-    public class Class1
-    {
-    }
-}

--- a/src/Couchbase.EntityFramework/Clauses/ExtentNameExpressionNode.cs
+++ b/src/Couchbase.EntityFramework/Clauses/ExtentNameExpressionNode.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.Extensions;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.EntityFramework.Clauses
+{
+    internal class ExtentNameExpressionNode : MethodCallExpressionNodeBase
+    {
+        public static readonly MethodInfo[] SupportedMethods =
+            { typeof(EnumerableExtensions).GetMethod("AsQueryable") };
+
+        /// <summary>
+        /// The <see cref="QueryModel.MainFromClause"/> will have an <see cref="IQuerySource.ItemName"/> composed of
+        /// this prefix followed by the <see cref="ExtentName"/>.
+        /// </summary>
+        public const string ItemNamePrefix = "__ExtentName_";
+
+        public ExtentNameExpressionNode(MethodCallExpressionParseInfo parseInfo, ConstantExpression extentName)
+            : base(parseInfo)
+        {
+            if (extentName == null)
+            {
+                throw new ArgumentNullException("extentName");
+            }
+            if (extentName.Type != typeof(string))
+            {
+                throw new ArgumentException("extentName must return a string", "extentName");
+            }
+
+            ExtentName = extentName;
+        }
+
+        public ConstantExpression ExtentName { get; private set; }
+
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        }
+
+        protected override void ApplyNodeSpecificSemantics(QueryModel queryModel,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            queryModel.MainFromClause.ItemName = ItemNamePrefix + (string) ExtentName.Value;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Clauses/HintClause.cs
+++ b/src/Couchbase.EntityFramework/Clauses/HintClause.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Text;
+using Couchbase.EntityFramework.QueryGeneration;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.EntityFramework.Clauses
+{
+    internal abstract class HintClause : IBodyClause
+    {
+        /// <summary>
+        ///     Accepts the specified visitor
+        /// </summary>
+        /// <param name="visitor">The visitor to accept.</param>
+        /// <param name="queryModel">The query model in whose context this clause is visited.</param>
+        /// <param name="index">
+        ///     The index of this clause in the <paramref name="queryModel" />'s
+        ///     <see cref="QueryModel.BodyClauses" /> collection.
+        /// </param>
+        public virtual void Accept(IQueryModelVisitor visitor, QueryModel queryModel, int index)
+        {
+            if (visitor is IN1QlQueryModelVisitor visitorx)
+            {
+                visitorx.VisitHintClause(this, queryModel, index);
+            }
+        }
+
+        /// <summary>
+        ///     Transforms all the expressions in this clause and its child objects via the given
+        ///     <paramref name="transformation" /> delegate.
+        /// </summary>
+        /// <param name="transformation">
+        ///     The transformation object. This delegate is called for each <see cref="Expression" /> within this
+        ///     clause, and those expressions will be replaced with what the delegate returns.
+        /// </param>
+        public virtual void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+        }
+
+        IBodyClause IBodyClause.Clone(CloneContext cloneContext)
+        {
+            return Clone(cloneContext);
+        }
+
+        /// <summary>
+        ///     Clones this clause.
+        /// </summary>
+        /// <param name="cloneContext">The clones of all query source clauses are registered with this <see cref="CloneContext" />.</param>
+        /// <returns></returns>
+        public abstract HintClause Clone(CloneContext cloneContext);
+
+        /// <summary>
+        ///     Appends the hint to the query <see cref="StringBuilder"/>.
+        /// </summary>
+        /// <param name="sb">The <see cref="StringBuilder"/>.</param>
+        public abstract void AppendToStringBuilder(StringBuilder sb);
+
+        public override string ToString()
+        {
+            return "use hint";
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Clauses/NestClause.cs
+++ b/src/Couchbase.EntityFramework/Clauses/NestClause.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Linq.Expressions;
+using Couchbase.EntityFramework.QueryGeneration;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.EntityFramework.Clauses
+{
+    internal class NestClause : IBodyClause, IQuerySource
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="NestClause" /> class.
+        /// </summary>
+        /// <param name="itemName">Name of the item returned by the nest clause</param>
+        /// <param name="itemType">Type of the item returned by the nest clause</param>
+        /// <param name="inner">The inner sequence being nested</param>
+        /// <param name="keySelector">Expression used to get the keys from each item in the outer sequence</param>
+        /// <param name="isLeftOuterNest">If true, indicates this is a LEFT OUTER NEST.  If false, this is an INNER NEST.</param>
+        public NestClause(string itemName, Type itemType, Expression inner, Expression keySelector, bool isLeftOuterNest)
+        {
+            ItemName = itemName;
+            ItemType = itemType;
+            InnerSequence = inner;
+            KeySelector = keySelector;
+            IsLeftOuterNest = isLeftOuterNest;
+        }
+
+        public string ItemName { get; set; }
+
+        public Type ItemType { get; set; }
+
+        /// <summary>
+        ///     Gets the inner sequence being nested
+        /// </summary>
+        public Expression InnerSequence { get; set; }
+
+        /// <summary>
+        ///     Gets the expression used to get the keys from each item in the outer sequence
+        /// </summary>
+        public Expression KeySelector { get; set; }
+
+        public bool IsLeftOuterNest { get; set; }
+
+        /// <summary>
+        ///     Accepts the specified visitor
+        /// </summary>
+        /// <param name="visitor">The visitor to accept.</param>
+        /// <param name="queryModel">The query model in whose context this clause is visited.</param>
+        /// <param name="index">
+        ///     The index of this clause in the <paramref name="queryModel" />'s
+        ///     <see cref="QueryModel.BodyClauses" /> collection.
+        /// </param>
+        public virtual void Accept(IQueryModelVisitor visitor, QueryModel queryModel, int index)
+        {
+            var visotorx = visitor as IN1QlQueryModelVisitor;
+            if (visotorx != null) visotorx.VisitNestClause(this, queryModel, index);
+        }
+
+        /// <summary>
+        ///     Transforms all the expressions in this clause and its child objects via the given
+        ///     <paramref name="transformation" /> delegate.
+        /// </summary>
+        /// <param name="transformation">
+        ///     The transformation object. This delegate is called for each <see cref="Expression" /> within this
+        ///     clause, and those expressions will be replaced with what the delegate returns.
+        /// </param>
+        public void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+            InnerSequence = transformation(InnerSequence);
+            KeySelector = transformation(KeySelector);
+        }
+
+        IBodyClause IBodyClause.Clone(CloneContext cloneContext)
+        {
+            return Clone(cloneContext);
+        }
+
+        /// <summary>
+        ///     Clones this clause.
+        /// </summary>
+        /// <param name="cloneContext">The clones of all query source clauses are registered with this <see cref="CloneContext" />.</param>
+        /// <returns></returns>
+        public virtual NestClause Clone(CloneContext cloneContext)
+        {
+            var clone = new NestClause(ItemName, ItemType, InnerSequence, KeySelector, IsLeftOuterNest);
+            return clone;
+        }
+
+        public override string ToString()
+        {
+            return String.Format("{0} {1} {2} in {3} on keys {4}",
+                IsLeftOuterNest ? "left outer nest" : "nest",
+                ItemType.Name,
+                ItemName,
+                InnerSequence,
+                KeySelector);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Clauses/NestExpressionNode.cs
+++ b/src/Couchbase.EntityFramework/Clauses/NestExpressionNode.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.Extensions;
+using Remotion.Linq;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.EntityFramework.Clauses
+{
+    internal class NestExpressionNode : MethodCallExpressionNodeBase, IQuerySourceExpressionNode
+    {
+        public static readonly MethodInfo[] SupportedMethods =
+        {
+            typeof(QueryExtensions).GetMethod("Nest"),
+            typeof(QueryExtensions).GetMethod("LeftOuterNest")
+        };
+
+        private readonly ResolvedExpressionCache<Expression> _cachedKeySelector;
+        private readonly ResolvedExpressionCache<Expression> _cachedResultSelector;
+
+        public NestExpressionNode(MethodCallExpressionParseInfo parseInfo,
+            Expression innerSequence,
+            LambdaExpression keySelector,
+            LambdaExpression resultSelector)
+            : base(parseInfo)
+        {
+            if (innerSequence == null)
+            {
+                throw new ArgumentNullException("innerSequence");
+            }
+
+            if (keySelector == null)
+            {
+                throw new ArgumentNullException("keySelector");
+            }
+            if (keySelector.Parameters.Count != 1)
+            {
+                throw new ArgumentException("Key selector must have exactly one parameter.", "keySelector");
+            }
+
+            if (resultSelector == null)
+            {
+                throw new ArgumentNullException("resultSelector");
+            }
+            if (resultSelector.Parameters.Count != 2)
+            {
+                throw new ArgumentException("Result selector must have exactly two parameters.", "resultSelector");
+            }
+
+            InnerSequence = innerSequence;
+            KeySelector = keySelector;
+            ResultSelector = resultSelector;
+            IsLeftOuterNest = parseInfo.ParsedExpression.Method.Name == "LeftOuterNest";
+
+            _cachedKeySelector = new ResolvedExpressionCache<Expression>(this);
+            _cachedResultSelector = new ResolvedExpressionCache<Expression>(this);
+        }
+
+        public Expression InnerSequence { get; private set; }
+        public LambdaExpression KeySelector { get; private set; }
+        public LambdaExpression ResultSelector { get; private set; }
+        public bool IsLeftOuterNest { get; private set; }
+
+        public Expression GetResolvedKeySelector(ClauseGenerationContext clauseGenerationContext)
+        {
+            return
+                _cachedKeySelector.GetOrCreate(
+                    r => r.GetResolvedExpression(KeySelector.Body, KeySelector.Parameters[0], clauseGenerationContext));
+        }
+
+        public Expression GetResolvedResultSelector(ClauseGenerationContext clauseGenerationContext)
+        {
+            return
+                _cachedResultSelector.GetOrCreate(
+                    r => r.GetResolvedExpression(
+                        QuerySourceExpressionNodeUtility.ReplaceParameterWithReference(
+                            this,
+                            ResultSelector.Parameters[1],
+                            ResultSelector.Body,
+                            clauseGenerationContext),
+                        ResultSelector.Parameters[0],
+                        clauseGenerationContext));
+        }
+
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        }
+
+        protected override void ApplyNodeSpecificSemantics(QueryModel queryModel,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            var nestClause = new NestClause(
+                ResultSelector.Parameters[1].Name,
+                ResultSelector.Parameters[1].Type,
+                InnerSequence,
+                GetResolvedKeySelector(clauseGenerationContext),
+                IsLeftOuterNest);
+
+            clauseGenerationContext.AddContextInfo(this, nestClause);
+            queryModel.BodyClauses.Add(nestClause);
+
+            var selectClause = queryModel.SelectClause;
+            selectClause.Selector = GetResolvedResultSelector(clauseGenerationContext);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Clauses/UseHashClause.cs
+++ b/src/Couchbase.EntityFramework/Clauses/UseHashClause.cs
@@ -1,0 +1,37 @@
+﻿using System.Text;
+using Couchbase.Linq;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.EntityFramework.Clauses
+{
+    internal class UseHashClause : HintClause
+    {
+        public UseHashClause(HashHintType hashType)
+        {
+            HashHintType = hashType;
+        }
+
+        public HashHintType HashHintType { get; set; }
+
+        /// <summary>
+        ///     Clones this clause.
+        /// </summary>
+        /// <param name="cloneContext">The clones of all query source clauses are registered with this <see cref="CloneContext" />.</param>
+        /// <returns></returns>
+        public override HintClause Clone(CloneContext cloneContext)
+        {
+            return new UseHashClause(HashHintType);
+        }
+
+        public override void AppendToStringBuilder(StringBuilder sb)
+        {
+            var hashTypeStr = HashHintType == HashHintType.Build ? "build" : "probe";
+            sb.AppendFormat("HASH ({0})", hashTypeStr);
+        }
+
+        public override string ToString()
+        {
+            return $"use hash ({HashHintType})";
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Clauses/UseHashExpressionNode.cs
+++ b/src/Couchbase.EntityFramework/Clauses/UseHashExpressionNode.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.Extensions;
+using Couchbase.Linq;
+using Remotion.Linq;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.EntityFramework.Clauses
+{
+    internal class UseHashExpressionNode : MethodCallExpressionNodeBase
+    {
+        public static readonly MethodInfo[] SupportedMethods =
+            typeof(QueryExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Where(p => p.Name == "UseHash")
+                .ToArray();
+
+        public UseHashExpressionNode(MethodCallExpressionParseInfo parseInfo, ConstantExpression hashHintType)
+            : base(parseInfo)
+        {
+            if (hashHintType.Type != typeof(HashHintType))
+            {
+                throw new ArgumentException($"{nameof(hashHintType)} must return a {nameof(EntityFramework.HashHintType)}", nameof(hashHintType));
+            }
+
+            HashHintType = hashHintType;
+        }
+
+        public ConstantExpression HashHintType { get; }
+
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        }
+
+        protected override void ApplyNodeSpecificSemantics(QueryModel queryModel,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            queryModel.BodyClauses.Add(new UseHashClause((HashHintType) HashHintType.Value));
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Clauses/UseIndexClause.cs
+++ b/src/Couchbase.EntityFramework/Clauses/UseIndexClause.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Text;
+using Couchbase.EntityFramework.QueryGeneration;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.EntityFramework.Clauses
+{
+    internal class UseIndexClause : HintClause
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="UseIndexClause" /> class.
+        /// </summary>
+        /// <param name="indexName">Name of the index to use.</param>
+        /// <param name="indexType">Type of the index to use.</param>
+        public UseIndexClause(string indexName, N1QlIndexType indexType)
+        {
+            if (string.IsNullOrEmpty(indexName))
+            {
+                throw new ArgumentNullException(nameof(indexName));
+            }
+
+            IndexName = indexName;
+            IndexType = indexType;
+        }
+
+        /// <summary>
+        ///     Name of the index to use.
+        /// </summary>
+        public string IndexName { get; set; }
+
+        /// <summary>
+        ///     Type of the index to use.
+        /// </summary>
+        public N1QlIndexType IndexType { get; set; }
+
+        /// <summary>
+        ///     Clones this clause.
+        /// </summary>
+        /// <param name="cloneContext">The clones of all query source clauses are registered with this <see cref="CloneContext" />.</param>
+        /// <returns></returns>
+        public override HintClause Clone(CloneContext cloneContext)
+        {
+            return new UseIndexClause(IndexName, IndexType);
+        }
+
+        public override void AppendToStringBuilder(StringBuilder sb)
+        {
+            var indexTypeStr = IndexType == N1QlIndexType.Gsi ? "GSI" : "VIEW";
+            sb.AppendFormat("INDEX ({0} USING {1})", N1QlHelpers.EscapeIdentifier(IndexName), indexTypeStr);
+        }
+
+        public override string ToString()
+        {
+            return $"use index {IndexName} using {IndexType.ToString().ToUpper()}";
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Clauses/UseIndexExpressionNode.cs
+++ b/src/Couchbase.EntityFramework/Clauses/UseIndexExpressionNode.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.Extensions;
+using Couchbase.Linq;
+using Remotion.Linq;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.EntityFramework.Clauses
+{
+    internal class UseIndexExpressionNode : MethodCallExpressionNodeBase
+    {
+        public static readonly MethodInfo[] SupportedMethods =
+            typeof(QueryExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Where(p => p.Name == "UseIndex")
+                .ToArray();
+
+        public UseIndexExpressionNode(MethodCallExpressionParseInfo parseInfo, ConstantExpression indexName, ConstantExpression indexType)
+            : base(parseInfo)
+        {
+            if (indexName == null)
+            {
+                throw new ArgumentNullException("indexName");
+            }
+            if (indexName.Type != typeof(string))
+            {
+                throw new ArgumentException("indexName must return a string", "indexName");
+            }
+
+            if (indexType.Type != typeof(N1QlIndexType))
+            {
+                throw new ArgumentException("indexType must return a N1QlIndexType", "indexType");
+            }
+
+            IndexName = indexName;
+            IndexType = indexType;
+        }
+
+        public ConstantExpression IndexName { get; private set; }
+        public ConstantExpression IndexType { get; private set; }
+
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        }
+
+        protected override void ApplyNodeSpecificSemantics(QueryModel queryModel,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            queryModel.BodyClauses.Add(new UseIndexClause((string) IndexName.Value, (N1QlIndexType) IndexType.Value));
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Clauses/UseKeysClause.cs
+++ b/src/Couchbase.EntityFramework/Clauses/UseKeysClause.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Linq.Expressions;
+using Couchbase.EntityFramework.QueryGeneration;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.EntityFramework.Clauses
+{
+    internal class UseKeysClause : IBodyClause
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="UseKeysClause" /> class.
+        /// </summary>
+        /// <param name="keys">Expression used to get the keys from each item in the outer sequence</param>
+        public UseKeysClause(Expression keys)
+        {
+            Keys = keys;
+        }
+
+        /// <summary>
+        ///     Gets the expression used to get the keys being selected
+        /// </summary>
+        public Expression Keys { get; set; }
+
+        /// <summary>
+        ///     Accepts the specified visitor
+        /// </summary>
+        /// <param name="visitor">The visitor to accept.</param>
+        /// <param name="queryModel">The query model in whose context this clause is visited.</param>
+        /// <param name="index">
+        ///     The index of this clause in the <paramref name="queryModel" />'s
+        ///     <see cref="QueryModel.BodyClauses" /> collection.
+        /// </param>
+        public virtual void Accept(IQueryModelVisitor visitor, QueryModel queryModel, int index)
+        {
+            var visotorx = visitor as IN1QlQueryModelVisitor;
+            if (visotorx != null) visotorx.VisitUseKeysClause(this, queryModel, index);
+        }
+
+        /// <summary>
+        ///     Transforms all the expressions in this clause and its child objects via the given
+        ///     <paramref name="transformation" /> delegate.
+        /// </summary>
+        /// <param name="transformation">
+        ///     The transformation object. This delegate is called for each <see cref="Expression" /> within this
+        ///     clause, and those expressions will be replaced with what the delegate returns.
+        /// </param>
+        public void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+            Keys = transformation(Keys);
+        }
+
+        IBodyClause IBodyClause.Clone(CloneContext cloneContext)
+        {
+            return Clone(cloneContext);
+        }
+
+        /// <summary>
+        ///     Clones this clause.
+        /// </summary>
+        /// <param name="cloneContext">The clones of all query source clauses are registered with this <see cref="CloneContext" />.</param>
+        /// <returns></returns>
+        public virtual UseKeysClause Clone(CloneContext cloneContext)
+        {
+            var clone = new UseKeysClause(Keys);
+            return clone;
+        }
+
+        public override string ToString()
+        {
+            return String.Format("use keys {0}", Keys);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Clauses/UseKeysExpressionNode.cs
+++ b/src/Couchbase.EntityFramework/Clauses/UseKeysExpressionNode.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.Extensions;
+using Remotion.Linq;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.EntityFramework.Clauses
+{
+    internal class UseKeysExpressionNode : MethodCallExpressionNodeBase
+    {
+        public static readonly MethodInfo[] SupportedMethods =
+        {
+            typeof (QueryExtensions).GetMethod("UseKeys")
+        };
+
+        public UseKeysExpressionNode(MethodCallExpressionParseInfo parseInfo, Expression keys)
+            : base(parseInfo)
+        {
+            if (keys == null)
+            {
+                throw new ArgumentNullException("keys");
+            }
+
+            Keys = keys;
+        }
+
+        public Expression Keys { get; private set; }
+
+        public override Expression Resolve(ParameterExpression inputParameter, Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        }
+
+        protected override void ApplyNodeSpecificSemantics(QueryModel queryModel,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            queryModel.BodyClauses.Add(new UseKeysClause(Keys));
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Couchbase.EntityFramework.csproj
+++ b/src/Couchbase.EntityFramework/Couchbase.EntityFramework.csproj
@@ -8,7 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.0" />
+    <PackageReference Include="Castle.Core" Version="4.3.1" />
+    <PackageReference Include="CouchbaseNetClient" Version="2.7.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Couchbase.EntityFramework/CouchbaseConsistencyException.cs
+++ b/src/Couchbase.EntityFramework/CouchbaseConsistencyException.cs
@@ -1,0 +1,18 @@
+﻿using Couchbase.Linq;
+
+namespace Couchbase.EntityFramework
+{
+    /// <summary>
+    /// Thrown if a write operation fails because the document has been modified since it was read.
+    /// </summary>
+    public class CouchbaseConsistencyException : CouchbaseWriteException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CouchbaseConsistencyException"/> class.
+        /// </summary>
+        /// <param name="failedResult">The <see cref="IOperationResult"/> of the failed operation.</param>
+        public CouchbaseConsistencyException(IOperationResult failedResult) : base(failedResult)
+        {
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/CouchbaseQueryException.cs
+++ b/src/Couchbase.EntityFramework/CouchbaseQueryException.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Couchbase.N1QL;
+
+namespace Couchbase.EntityFramework
+{
+    /// <summary>
+    /// Thrown if an error occurs during the execution of a LINQ N1QL query.
+    /// </summary>
+    public class CouchbaseQueryException : Exception
+    {
+        private readonly ReadOnlyCollection<Error> _errors;
+
+        /// <summary>
+        /// Errors returned by the Couchbase Server, if any.
+        /// </summary>
+        public ReadOnlyCollection<Error> Errors
+        {
+            get { return _errors; }
+        }
+
+        internal CouchbaseQueryException(string message) :
+            this(message, (Exception) null)
+        {
+        }
+
+        internal CouchbaseQueryException(string message, Exception innerException) :
+            base(message, innerException)
+        {
+            _errors = new ReadOnlyCollection<Error>(new Error[] {});
+        }
+
+        internal CouchbaseQueryException(string message, IList<Error> errors) :
+            base(message)
+        {
+            _errors = new ReadOnlyCollection<Error>(errors);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/CouchbaseWriteException.cs
+++ b/src/Couchbase.EntityFramework/CouchbaseWriteException.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Couchbase.IO;
+
+namespace Couchbase.EntityFramework
+{
+    /// <summary>
+    /// Thrown if a write operation fails - use the InnerException, Message and ResponseStatus properties to determine what went wrong.
+    /// </summary>
+    public class CouchbaseWriteException : Exception
+    {
+        private readonly IOperationResult _failedResult;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CouchbaseWriteException"/> class.
+        /// </summary>
+        /// <param name="failedResult">The <see cref="IOperationResult"/> of the failed operation.</param>
+        public CouchbaseWriteException(IOperationResult failedResult)
+            : base(failedResult.Message, failedResult.Exception)
+        {
+            _failedResult = failedResult;
+        }
+
+        /// <summary>
+        /// Gets the failure <see cref="ResponseStatus"/>.
+        /// </summary>
+        /// <value>
+        /// The response status.
+        /// </value>
+        public ResponseStatus ResponseStatus
+        {
+            get { return _failedResult.Status; }
+        }
+    }
+}
+
+#region [ License information          ]
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2015 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/
+
+#endregion

--- a/src/Couchbase.EntityFramework/DocumentNotFoundException.cs
+++ b/src/Couchbase.EntityFramework/DocumentNotFoundException.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+namespace Couchbase.EntityFramework
+{
+    /// <summary>
+    /// Thrown if a given key cannot be found in the bucket.
+    /// </summary>
+    public class DocumentNotFoundException : Exception
+    {
+        /// <summary>
+        /// Creates a new DocumentNotFoundException.
+        /// </summary>
+        /// <param name="message">Exception message.</param>
+        public DocumentNotFoundException(string message)
+            : base(message)
+        {
+        }
+    }
+}
+
+#region [ License information          ]
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2015 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/
+
+#endregion

--- a/src/Couchbase.EntityFramework/Execution/BucketQueryExecutor.cs
+++ b/src/Couchbase.EntityFramework/Execution/BucketQueryExecutor.cs
@@ -1,0 +1,319 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase.Configuration.Client;
+using Couchbase.Core;
+using Couchbase.Core.Serialization;
+using Couchbase.EntityFramework.Operators;
+using Couchbase.EntityFramework.Proxies;
+using Couchbase.EntityFramework.QueryGeneration;
+using Couchbase.EntityFramework.QueryGeneration.MemberNameResolvers;
+using Couchbase.EntityFramework.Utils;
+using Couchbase.EntityFramework.Versioning;
+using Couchbase.Logging;
+using Couchbase.N1QL;
+using Remotion.Linq;
+
+namespace Couchbase.EntityFramework.Execution
+{
+    internal class BucketQueryExecutor : IBucketQueryExecutor
+    {
+        private readonly ILog _log = LogManager.GetLogger<BucketQueryExecutor>();
+        private readonly IBucket _bucket;
+        private readonly ClientConfiguration _configuration;
+        private readonly IBucketContext _bucketContext;
+        private ITypeSerializer _serializer;
+
+        public string BucketName
+        {
+            get { return _bucket.Name; }
+        }
+
+        /// <summary>
+        /// If true, generate change tracking proxies for documents during deserialization.
+        /// </summary>
+        public bool EnableProxyGeneration
+        {
+            get { return _bucketContext.ChangeTrackingEnabled; }
+        }
+
+        /// <summary>
+        /// Specifies the consistency guarantee/constraint for index scanning.
+        /// </summary>
+        public ScanConsistency? ScanConsistency { get; set; }
+
+        /// <summary>
+        /// Specifies the maximum time the client is willing to wait for an index to catch up to the consistency requirement in the request.
+        /// If an index has to catch up, and the time is exceed doing so, an error is returned.
+        /// </summary>
+        public TimeSpan? ScanWait { get; set; }
+
+        public MutationState MutationState { get; private set; }
+
+        /// <inheritdoc cref="IBucketQueryExecutor.UseStreaming"/>
+        public bool UseStreaming { get; set; }
+
+        private ITypeSerializer Serializer
+        {
+            get
+            {
+                if (_serializer == null)
+                {
+                    var serializerProvider = _bucketContext.Bucket as ITypeSerializerProvider;
+
+                    _serializer = serializerProvider?.Serializer ?? _configuration.Serializer.Invoke();
+                }
+
+                return _serializer;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new BucketQueryExecutor.
+        /// </summary>
+        /// <param name="bucket"><see cref="IBucket"/> to query.</param>
+        /// <param name="configuration"><see cref="ClientConfiguration"/> used during the query.</param>
+        /// <param name="bucketContext">The context object for tracking and managing changes to documents.</param>
+        public BucketQueryExecutor(IBucket bucket, ClientConfiguration configuration, IBucketContext bucketContext)
+        {
+            _bucket = bucket;
+            _configuration = configuration;
+            _bucketContext = bucketContext;
+        }
+
+        /// <summary>
+        /// Requires that the indexes but up to date with a <see cref="N1QL.MutationState"/> before the query is executed.
+        /// </summary>
+        /// <param name="state"><see cref="N1QL.MutationState"/> used for conistency controls.</param>
+        /// <remarks>If called multiple times, the states from the calls are combined.</remarks>
+        public void ConsistentWith(MutationState state)
+        {
+            if (state == null)
+            {
+                return;
+            }
+
+            if (MutationState == null)
+            {
+                MutationState = new MutationState();
+            }
+
+            MutationState.Add(state);
+        }
+
+        /// <summary>
+        /// Determines if proxies should be generated, based on the given query model and return type.
+        /// </summary>
+        /// <typeparam name="T">Return type expected for query rows.</typeparam>
+        /// <param name="queryModel">Query model.</param>
+        /// <returns>Returns true if proxies should be generated, based on the given query model and return type.</returns>
+        /// <remarks>
+        /// Queries with select projections don't need change tracking, because there is no original source document to be
+        /// updated if their properties are changed.  So only create proxies if the rows being returned by the query are
+        /// plain instances of the document type being queried, without select projections.
+        /// </remarks>
+        private bool ShouldGenerateProxies<T>(QueryModel queryModel)
+        {
+            if (!EnableProxyGeneration)
+            {
+                return false;
+            }
+
+            var mainFromClauseType = queryModel.MainFromClause.ItemType;
+
+            return (mainFromClauseType == typeof (T)) || (mainFromClauseType == typeof (ScalarResult<T>));
+        }
+
+        private void ApplyQueryRequestSettings(LinqQueryRequest queryRequest, bool generateProxies)
+        {
+            if (ScanConsistency.HasValue)
+            {
+                queryRequest.ScanConsistency(ScanConsistency.Value);
+            }
+            if (ScanWait.HasValue)
+            {
+                queryRequest.ScanWait(ScanWait.Value);
+            }
+            if (MutationState != null)
+            {
+                queryRequest.ConsistentWith(MutationState);
+            }
+
+            if (UseStreaming)
+            {
+                if (generateProxies)
+                {
+                    _log.Info("Query result streaming is not supported with change tracking, streaming disabled");
+                }
+                else
+                {
+                    queryRequest.UseStreaming(true);
+                }
+            }
+        }
+
+        public IEnumerable<T> ExecuteCollection<T>(QueryModel queryModel)
+        {
+            ScalarResultBehavior scalarResultBehavior;
+            bool generateProxies = ShouldGenerateProxies<T>(queryModel);
+
+            var commandData = GenerateQuery(queryModel, generateProxies, out scalarResultBehavior);
+
+            var queryRequest = new LinqQueryRequest(commandData, scalarResultBehavior);
+            ApplyQueryRequestSettings(queryRequest, generateProxies);
+
+            if (generateProxies)
+            {
+                // Proxy generation was requested, and the
+                queryRequest.DataMapper = new DocumentProxyDataMapper<T>(Serializer, (IChangeTrackableContext)_bucketContext);
+            }
+
+            if (queryModel.ResultOperators.Any(p => p is ToQueryRequestResultOperator))
+            {
+                // ToQueryRequest was called on this LINQ query, so we should return the N1QL query in a QueryRequest object
+                // The IEnumerable wrapper will be stripped by ExecuteSingle.
+
+                return new[] { queryRequest } as IEnumerable<T>;
+            }
+
+            return ExecuteCollection<T>(queryRequest);
+        }
+
+        /// <summary>
+        /// Execute a <see cref="LinqQueryRequest"/>.
+        /// </summary>
+        /// <typeparam name="T">Type returned by the query.</typeparam>
+        /// <param name="queryRequest">Request to execute.</param>
+        /// <returns>List of objects returned by the request.</returns>
+        public IEnumerable<T> ExecuteCollection<T>(LinqQueryRequest queryRequest)
+        {
+            if (!queryRequest.ScalarResultBehavior.ResultExtractionRequired)
+            {
+                var result = _bucket.Query<T>(queryRequest);
+
+                return ParseResult(result);
+            }
+            else
+            {
+                var result = _bucket.Query<ScalarResult<T>>(queryRequest);
+
+                return queryRequest.ScalarResultBehavior.ApplyResultExtraction(ParseResult(result));
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously execute a <see cref="LinqQueryRequest"/>.
+        /// </summary>
+        /// <typeparam name="T">Type returned by the query.</typeparam>
+        /// <param name="queryRequest">Request to execute.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Task which contains a list of objects returned by the request when complete.</returns>
+        public async Task<IEnumerable<T>> ExecuteCollectionAsync<T>(LinqQueryRequest queryRequest, CancellationToken cancellationToken)
+        {
+            if (!queryRequest.ScalarResultBehavior.ResultExtractionRequired)
+            {
+                var result = await _bucket.QueryAsync<T>(queryRequest, cancellationToken).ConfigureAwait(false);
+
+                return ParseResult(result);
+            }
+            else
+            {
+                var result = await _bucket.QueryAsync<ScalarResult<T>>(queryRequest, cancellationToken).ConfigureAwait(false);
+
+                return queryRequest.ScalarResultBehavior.ApplyResultExtraction(ParseResult(result));
+            }
+        }
+
+        /// <summary>
+        /// Parses a <see cref="IQueryResult{T}"/>, returning the result rows.
+        /// If there are any errors, throws exceptions instead.
+        /// </summary>
+        /// <typeparam name="T">Result type.</typeparam>
+        /// <param name="result">Result to parse.</param>
+        /// <returns>Rows in the result.</returns>
+        private IEnumerable<T> ParseResult<T>(IQueryResult<T> result)
+        {
+            if (!result.Success)
+            {
+                if (result.Errors != null && (result.Errors.Count > 0))
+                {
+                    var message = result.Errors.Count == 1 ?
+                        result.Errors[0].Message :
+                        ExceptionMsgs.QueryExecutionMultipleErrors;
+
+                    throw new CouchbaseQueryException(message ?? ExceptionMsgs.QueryExecutionUnknownError, result.Errors);
+                }
+                else if (result.Exception != null)
+                {
+                    throw new CouchbaseQueryException(ExceptionMsgs.QueryExecutionException, result.Exception);
+                }
+                else
+                {
+                    throw new CouchbaseQueryException(ExceptionMsgs.QueryExecutionUnknownError);
+                }
+            }
+
+            return result;
+        }
+
+        public T ExecuteScalar<T>(QueryModel queryModel)
+        {
+            return ExecuteSingle<T>(queryModel, false);
+        }
+
+        public T ExecuteSingle<T>(QueryModel queryModel, bool returnDefaultWhenEmpty)
+        {
+            var result = returnDefaultWhenEmpty
+                ? ExecuteCollection<T>(queryModel).SingleOrDefault()
+                : ExecuteCollection<T>(queryModel).Single();
+
+            return result;
+        }
+
+        public async Task<T> ExecuteSingleAsync<T>(LinqQueryRequest queryRequest, CancellationToken cancellationToken)
+        {
+            var resultSet = await ExecuteCollectionAsync<T>(queryRequest, cancellationToken).ConfigureAwait(false);
+
+            return queryRequest.ReturnDefaultWhenEmpty
+                ? resultSet.SingleOrDefault()
+                : resultSet.Single();
+        }
+
+        public string GenerateQuery(QueryModel queryModel, bool selectDocumentMetadata, out ScalarResultBehavior scalarResultBehavior)
+        {
+            // If ITypeSerializer is an IExtendedTypeSerializer, use it as the member name resolver
+            // Otherwise fallback to the legacy behavior which assumes we're using Newtonsoft.Json
+            // Note that DefaultSerializer implements IExtendedTypeSerializer, but has the same logic as JsonNetMemberNameResolver
+
+            var serializer = Serializer as IExtendedTypeSerializer;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            var memberNameResolver = serializer != null ?
+                (IMemberNameResolver)new ExtendedTypeSerializerMemberNameResolver(serializer) :
+                (IMemberNameResolver)new JsonNetMemberNameResolver(_configuration.SerializationSettings.ContractResolver);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            var methodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider();
+
+            var queryGenerationContext = new N1QlQueryGenerationContext
+            {
+                MemberNameResolver = memberNameResolver,
+                MethodCallTranslatorProvider = methodCallTranslatorProvider,
+                Serializer = serializer,
+                SelectDocumentMetadata = selectDocumentMetadata,
+                ClusterVersion = VersionProvider.Current.GetVersion(_bucket)
+            };
+
+            var visitor = new N1QlQueryModelVisitor(queryGenerationContext);
+            visitor.VisitQueryModel(queryModel);
+
+            var query = visitor.GetQuery();
+            _log.Debug("Generated query: {0}", query);
+
+            scalarResultBehavior = visitor.ScalarResultBehavior;
+            return query;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Execution/IBucketQueryExecutor.cs
+++ b/src/Couchbase.EntityFramework/Execution/IBucketQueryExecutor.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase.EntityFramework.QueryGeneration;
+using Couchbase.N1QL;
+using Remotion.Linq;
+
+namespace Couchbase.EntityFramework.Execution
+{
+    /// <summary>
+    /// Extends <see cref="IQueryExecutor"/> with routines to execute a <see cref="LinqQueryRequest"/> asynchronously.
+    /// </summary>
+    internal interface IBucketQueryExecutor : IQueryExecutor
+    {
+        /// <summary>
+        /// Specifies the consistency guarantee/constraint for index scanning.
+        /// </summary>
+        ScanConsistency? ScanConsistency { get; set; }
+
+        /// <summary>
+        /// Specifies the maximum time the client is willing to wait for an index to catch up to the consistency requirement in the request.
+        /// If an index has to catch up, and the time is exceed doing so, an error is returned.
+        /// </summary>
+        TimeSpan? ScanWait { get; set; }
+
+        /// <summary>
+        /// Specifies if the query results should be streamed, reducing memory utilzation for large result sets.
+        /// </summary>
+        /// <remarks>The default is false.</remarks>
+        bool UseStreaming { get; set; }
+
+        /// <summary>
+        /// Requires that the indexes but up to date with a <see cref="MutationState"/> before the query is executed.
+        /// </summary>
+        /// <param name="state"><see cref="MutationState"/> used for conistency controls.</param>
+        /// <remarks>If called multiple times, the states from the calls are combined.</remarks>
+        void ConsistentWith(MutationState state);
+
+        /// <summary>
+        /// Asynchronously execute a <see cref="LinqQueryRequest"/>.
+        /// </summary>
+        /// <typeparam name="T">Type returned by the query.</typeparam>
+        /// <param name="queryRequest">Request to execute.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Task which contains a list of objects returned by the request when complete.</returns>
+        Task<IEnumerable<T>> ExecuteCollectionAsync<T>(LinqQueryRequest queryRequest, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously execute a <see cref="LinqQueryRequest"/> that returns a single result.
+        /// </summary>
+        /// <typeparam name="T">Type returned by the query.</typeparam>
+        /// <param name="queryRequest">Request to execute.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Task which contains the object returned by the request when complete.</returns>
+        Task<T> ExecuteSingleAsync<T>(LinqQueryRequest queryRequest, CancellationToken cancellationToken);
+    }
+}

--- a/src/Couchbase.EntityFramework/Execution/IBucketQueryExecutorProvider.cs
+++ b/src/Couchbase.EntityFramework/Execution/IBucketQueryExecutorProvider.cs
@@ -1,0 +1,13 @@
+﻿namespace Couchbase.EntityFramework.Execution
+{
+    /// <summary>
+    /// Provides access to an <see cref="IBucketQueryExecutor"/>.
+    /// </summary>
+    internal interface IBucketQueryExecutorProvider
+    {
+        /// <summary>
+        /// Get the <see cref="IBucketQueryExecutor"/>.
+        /// </summary>
+        IBucketQueryExecutor BucketQueryExecutor { get; }
+    }
+}

--- a/src/Couchbase.EntityFramework/Execution/ScalarResult.cs
+++ b/src/Couchbase.EntityFramework/Execution/ScalarResult.cs
@@ -1,0 +1,12 @@
+﻿namespace Couchbase.EntityFramework.Execution
+{
+    /// <summary>
+    /// Used to extract the result row from an Any, All, or aggregate operation.
+    /// </summary>
+    internal class ScalarResult<T>
+    {
+        // ReSharper disable once InconsistentNaming
+        // Note: must be virtual to support change tracking for First/Single
+        public virtual T result { get; set; }
+    }
+}

--- a/src/Couchbase.EntityFramework/Execution/ScalarResultBehavior.cs
+++ b/src/Couchbase.EntityFramework/Execution/ScalarResultBehavior.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Couchbase.EntityFramework.Execution
+{
+    /// <summary>
+    /// Defines the behaviors related to scalar results, which must typically be extracted
+    /// from an attribute named "result".  This typically applies to aggregate operations, as well as
+    /// <see cref="Queryable.Any{T}(IQueryable{T})"/> and <see cref="Queryable.All{T}"/> operations.
+    /// </summary>
+    internal class ScalarResultBehavior
+    {
+        /// <summary>
+        /// If true, indicates that result extraction is required.  The query should be executed with a return type
+        /// of <see cref="ScalarResult{T}"/>, and then passed through <see cref="ApplyResultExtraction{T}"/>.
+        /// </summary>
+        public bool ResultExtractionRequired { get; set; }
+
+        /// <summary>
+        /// If NoRowsResult is not null, and if no rows are returned, then a single row with this value is returned instead.
+        /// This is used to return the expected results for <see cref="Queryable.Any{T}(IQueryable{T})"/> and
+        /// <see cref="Queryable.All{T}"/> operations.
+        /// </summary>
+        public object NoRowsResult { get; set; }
+
+        /// <summary>
+        /// Applies result extraction to a collection of <see cref="ScalarResult{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">Result type being extracted.</typeparam>
+        /// <param name="source">Collection of <see cref="ScalarResult{T}"/>.</param>
+        /// <returns>Collection of <typeparamref name="T"/>.</returns>
+        public IEnumerable<T> ApplyResultExtraction<T>(IEnumerable<ScalarResult<T>> source)
+        {
+            var result = source.Select(p => p.result);
+
+            if (NoRowsResult != null)
+            {
+                var typeCastNoRowsResult = (T) NoRowsResult;
+                if (typeCastNoRowsResult == null)
+                {
+                    throw new InvalidOperationException(
+                        string.Format("Cannot apply result extraction, NoRowsResult is not of type '{0}'",
+                            typeof (T).FullName));
+                }
+
+                result = result.DefaultIfEmpty(typeCastNoRowsResult);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Extensions/EnumerableExtensions.cs
+++ b/src/Couchbase.EntityFramework/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Couchbase.EntityFramework.Metadata;
+using Couchbase.Linq;
+
+namespace Couchbase.EntityFramework.Extensions
+{
+    /// <summary>
+    /// Extensions to <see cref="IEnumerable{T}"/> which emulate query extensions in <see cref="QueryExtensions"/>.
+    /// This helps to provide support for unit tests against a fake <see cref="BucketContext"/>.
+    /// </summary>
+    public static class EnumerableExtensions
+    {
+
+        #region Nest
+
+        /// <summary>
+        ///     Emulates Nest for N1QL against an IEnumerable
+        /// </summary>
+        /// <typeparam name="TOuter">Type of the source sequence</typeparam>
+        /// <typeparam name="TInner">Type of the inner sequence being nested</typeparam>
+        /// <typeparam name="TResult">Type of the result sequence</typeparam>
+        /// <param name="outer"></param>
+        /// <param name="inner">Sequence to be nested</param>
+        /// <param name="keySelector">Expression to get the list of keys to nest for an item in the source sequence.  Should return a list of strings.</param>
+        /// <param name="resultSelector">Expression that returns the result</param>
+        /// <returns></returns>
+        public static IEnumerable<TResult> Nest<TOuter, TInner, TResult>(
+            this IEnumerable<TOuter> outer, IEnumerable<TInner> inner,
+            Func<TOuter, IEnumerable<string>> keySelector,
+            Func<TOuter, IEnumerable<TInner>, TResult> resultSelector) where TInner : IDocumentMetadataProvider
+        {
+            return outer.Nest(inner, keySelector, resultSelector, true);
+        }
+
+        /// <summary>
+        ///     Emulates LeftNest for N1QL against an IEnumerable
+        /// </summary>
+        /// <typeparam name="TOuter">Type of the source sequence</typeparam>
+        /// <typeparam name="TInner">Type of the inner sequence being nested</typeparam>
+        /// <typeparam name="TResult">Type of the result sequence</typeparam>
+        /// <param name="outer"></param>
+        /// <param name="inner">Sequence to be nested</param>
+        /// <param name="keySelector">Expression to get the list of keys to nest for an item in the source sequence.  Should return a list of strings.</param>
+        /// <param name="resultSelector">Expression that returns the result</param>
+        /// <returns></returns>
+        public static IEnumerable<TResult> LeftOuterNest<TOuter, TInner, TResult>(
+            this IEnumerable<TOuter> outer, IEnumerable<TInner> inner,
+            Func<TOuter, IEnumerable<string>> keySelector,
+            Func<TOuter, IEnumerable<TInner>, TResult> resultSelector) where TInner : IDocumentMetadataProvider
+        {
+            return outer.Nest(inner, keySelector, resultSelector, false);
+        }
+
+        /// <summary>
+        ///     Emulates Nest for N1QL against an IEnumerable
+        /// </summary>
+        /// <typeparam name="TOuter">Type of the source sequence</typeparam>
+        /// <typeparam name="TInner">Type of the inner sequence being nested</typeparam>
+        /// <typeparam name="TResult">Type of the result sequence</typeparam>
+        /// <param name="outer"></param>
+        /// <param name="inner">Sequence to be nested</param>
+        /// <param name="keySelector">Expression to get the list of keys to nest for an item in the source sequence.  Should return a list of strings.</param>
+        /// <param name="resultSelector">Expression that returns the result</param>
+        /// <param name="innerNest">Excludes results where no matches are found in the inner sequence</param>
+        /// <returns></returns>
+        private static IEnumerable<TResult> Nest<TOuter, TInner, TResult>(
+            this IEnumerable<TOuter> outer, IEnumerable<TInner> inner,
+            Func<TOuter, IEnumerable<string>> keySelector,
+            Func<TOuter, IEnumerable<TInner>, TResult> resultSelector,
+            bool innerNest) where TInner : IDocumentMetadataProvider
+        {
+            if (inner == null)
+            {
+                throw new ArgumentNullException("inner");
+            }
+            if (outer == null)
+            {
+                throw new ArgumentNullException("outer");
+            }
+            if (keySelector == null)
+            {
+                throw new ArgumentNullException("keySelector");
+            }
+            if (resultSelector == null)
+            {
+                throw new ArgumentNullException("resultSelector");
+            }
+
+            // Create a dictionary on the inner sequence, based on document key
+            // This ensures that the inner sequence is only enumerated once
+            // And that lookups are fast
+            var innerDictionary = inner.ToDictionary(p => N1QlFunctions.Key(p));
+
+            return outer
+                .Select(outerDocument =>
+                {
+                    var keys = keySelector.Invoke(outerDocument);
+
+                    List<TInner> innerDocuments = null;
+                    if (keys != null)
+                    {
+                        innerDocuments = keys.Select(key =>
+                        {
+                            TInner innerDocument;
+                            if (!innerDictionary.TryGetValue(key, out innerDocument))
+                            {
+                                innerDocument = default(TInner); // return null when not found
+                            }
+
+                            return innerDocument;
+                        })
+                            .Where(p => p != null) // skip any documents that weren't found in the dictionary
+                            .ToList();
+                    }
+
+                    if (innerNest && (innerDocuments == null || innerDocuments.Count == 0))
+                    {
+                        // For inner nest, return null if there are no inner documents
+                        return default(TResult);
+                    }
+
+                    return resultSelector.Invoke(outerDocument, innerDocuments);
+                })
+                .Where(p => p != null); // Filter out any null results returned due to inner nest or a null from the resultSelector
+        }
+
+        #endregion
+
+        #region UseKeys
+
+        /// <summary>
+        ///     Emulates UseKeys for N1QL against an IEnumerable
+        /// </summary>
+        /// <typeparam name="T">Type of the source sequence</typeparam>
+        /// <param name="items">Items being filtered</param>
+        /// <param name="keys">Keys to be selected</param>
+        /// <returns></returns>
+        public static IEnumerable<T> UseKeys<T>(
+            this IEnumerable<T> items, IEnumerable<string> keys) where T : IDocumentMetadataProvider
+        {
+            if (items == null)
+            {
+                throw new ArgumentNullException("items");
+            }
+            if (keys == null)
+            {
+                throw new ArgumentNullException("keys");
+            }
+
+            return items.Where(p => keys.Contains(N1QlFunctions.Key(p)));
+        }
+
+        #endregion
+
+        #region AsQueryable
+
+        /// <summary>
+        /// Converts a nested array into a queryable array, specifying the extent name to use in the generated N1QL query.
+        /// This may be important to ensure that array indexes are used for query optimization.
+        /// </summary>
+        /// <typeparam name="T">Type of items being queried.</typeparam>
+        /// <param name="source">Items being queried.</param>
+        /// <param name="extentName">Name of the extent to use.</param>
+        /// <returns></returns>
+        public static IQueryable<T> AsQueryable<T>(this IEnumerable<T> source, string extentName)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+
+            var queryable = source.AsQueryable();
+
+            return queryable.Provider.CreateQuery<T>(
+                Expression.Call(
+                    typeof(EnumerableExtensions).GetMethod("AsQueryable")
+                        .MakeGenericMethod(typeof(T)),
+                    queryable.Expression,
+                    Expression.Constant(extentName)));
+        }
+
+        #endregion
+    }
+}

--- a/src/Couchbase.EntityFramework/Extensions/QueryExtensions.cs
+++ b/src/Couchbase.EntityFramework/Extensions/QueryExtensions.cs
@@ -1,0 +1,581 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase.EntityFramework.Execution;
+using Couchbase.EntityFramework.Metadata;
+using Couchbase.EntityFramework.QueryGeneration;
+using Couchbase.N1QL;
+using Remotion.Linq.Parsing.ExpressionVisitors;
+
+namespace Couchbase.EntityFramework.Extensions
+{
+    /// <summary>
+    /// Extentions to <see cref="IQueryable{T}" /> for use in queries against a <see cref="BucketContext"/>.
+    /// </summary>
+    public static class QueryExtensions
+    {
+        #region Nest
+
+        /// <summary>
+        ///     Nest for N1QL. (outer.Nest(inner, keySelector, resultSelector) translates to NEST inner ON KEYS outer.keySelector)
+        /// </summary>
+        /// <typeparam name="TOuter">Type of the source sequence</typeparam>
+        /// <typeparam name="TInner">Type of the inner sequence being nested</typeparam>
+        /// <typeparam name="TResult">Type of the result sequence</typeparam>
+        /// <param name="outer"></param>
+        /// <param name="inner">Sequence to be nested</param>
+        /// <param name="keySelector">Expression to get the list of keys to nest for an item in the source sequence.  Should return a list of strings.</param>
+        /// <param name="resultSelector">Expression that returns the result</param>
+        /// <remarks>Returns a result for values in the outer sequence only if matching values in the inner sequence are found</remarks>
+        /// <returns>Modified IQueryable</returns>
+        public static IQueryable<TResult> Nest<TOuter, TInner, TResult>(
+            this IQueryable<TOuter> outer,
+            IEnumerable<TInner> inner,
+            Expression<Func<TOuter, IEnumerable<string>>> keySelector,
+            Expression<Func<TOuter, IEnumerable<TInner>, TResult>> resultSelector)
+        {
+            if (inner == null)
+            {
+                throw new ArgumentNullException("inner");
+            }
+            if (outer == null)
+            {
+                throw new ArgumentNullException("outer");
+            }
+            if (keySelector == null)
+            {
+                throw new ArgumentNullException("keySelector");
+            }
+            if (resultSelector == null)
+            {
+                throw new ArgumentNullException("resultSelector");
+            }
+
+            if (outer is EnumerableQuery<TOuter>)
+            {
+                // If outer is an IEnumerable converted to IQueryable via AsQueryable
+                // Then we need to just call the IEnumerable implementation
+
+                if (!typeof (IDocumentMetadataProvider).IsAssignableFrom(typeof (TInner)))
+                {
+                    throw new NotSupportedException("Inner Sequence Items Must Implement IDocumentMetadataProvider To Function With EnumerableQuery<T>");
+                }
+
+                var methodCall =
+                    Expression.Call(
+                        typeof(EnumerableExtensions).GetMethod("Nest")
+                            .MakeGenericMethod(typeof(TOuter), typeof(TInner), typeof(TResult)),
+                        Expression.Constant(outer, typeof(IEnumerable<TOuter>)),
+                        Expression.Constant(inner, typeof(IEnumerable<TInner>)),
+                        keySelector,
+                        resultSelector);
+
+                return outer.Provider.CreateQuery<TResult>(
+                    Expression.Call(
+                        typeof(Queryable).GetMethods().First(p => p.Name == "AsQueryable" && p.GetGenericArguments().Length == 1)
+                            .MakeGenericMethod(typeof(TResult)),
+                        methodCall));
+            }
+            else
+            {
+                return outer.Provider.CreateQuery<TResult>(
+                    Expression.Call(
+                        typeof(QueryExtensions).GetMethod("Nest")
+                            .MakeGenericMethod(typeof(TOuter), typeof(TInner), typeof(TResult)),
+                        outer.Expression,
+                        GetSourceExpression(inner),
+                        Expression.Quote(keySelector),
+                        Expression.Quote(resultSelector)));
+            }
+        }
+
+        /// <summary>
+        ///     Nest for N1QL. (outer.LeftNest(inner, keySelector, resultSelector) translates to LEFT OUTER NEST inner ON KEYS outer.keySelector)
+        /// </summary>
+        /// <typeparam name="TOuter">Type of the source sequence</typeparam>
+        /// <typeparam name="TInner">Type of the inner sequence being nested</typeparam>
+        /// <typeparam name="TResult">Type of the result sequence</typeparam>
+        /// <param name="outer"></param>
+        /// <param name="inner">Sequence to be nested</param>
+        /// <param name="keySelector">Expression to get the list of keys to nest for an item in the source sequence.  Should return a list of strings.</param>
+        /// <param name="resultSelector">Expression that returns the result</param>
+        /// <remarks>Returns a result for all values in the outer sequence</remarks>
+        /// <returns>Modified IQueryable</returns>
+        public static IQueryable<TResult> LeftOuterNest<TOuter, TInner, TResult>(
+            this IQueryable<TOuter> outer,
+            IEnumerable<TInner> inner,
+            Expression<Func<TOuter, IEnumerable<string>>> keySelector,
+            Expression<Func<TOuter, IEnumerable<TInner>, TResult>> resultSelector)
+        {
+            if (inner == null)
+            {
+                throw new ArgumentNullException("inner");
+            }
+            if (outer == null)
+            {
+                throw new ArgumentNullException("outer");
+            }
+            if (keySelector == null)
+            {
+                throw new ArgumentNullException("keySelector");
+            }
+            if (resultSelector == null)
+            {
+                throw new ArgumentNullException("resultSelector");
+            }
+
+            if (outer is EnumerableQuery<TOuter>)
+            {
+                // If outer is an IEnumerable converted to IQueryable via AsQueryable
+                // Then we need to just call the IEnumerable implementation
+
+                if (!typeof(IDocumentMetadataProvider).IsAssignableFrom(typeof(TInner)))
+                {
+                    throw new NotSupportedException("Inner Sequence Items Must Implement IDocumentMetadataProvider To Function With EnumerableQuery<T>");
+                }
+
+                var methodCall =
+                    Expression.Call(
+                        typeof(EnumerableExtensions).GetMethod("LeftOuterNest")
+                            .MakeGenericMethod(typeof(TOuter), typeof(TInner), typeof(TResult)),
+                        Expression.Constant(outer, typeof(IEnumerable<TOuter>)),
+                        Expression.Constant(inner, typeof(IEnumerable<TInner>)),
+                        keySelector,
+                        resultSelector);
+
+                return outer.Provider.CreateQuery<TResult>(
+                    Expression.Call(
+                        typeof(Queryable).GetMethods().First(p => p.Name == "AsQueryable" && p.GetGenericArguments().Length == 1)
+                            .MakeGenericMethod(typeof(TResult)),
+                        methodCall));
+            }
+            else
+            {
+                return outer.Provider.CreateQuery<TResult>(
+                    Expression.Call(
+                        typeof(QueryExtensions).GetMethod("LeftOuterNest")
+                            .MakeGenericMethod(typeof(TOuter), typeof(TInner), typeof(TResult)),
+                        outer.Expression,
+                        GetSourceExpression(inner),
+                        Expression.Quote(keySelector),
+                        Expression.Quote(resultSelector)));
+            }
+        }
+
+        #endregion
+
+        #region UseKeys
+
+        /// <summary>
+        ///     Filters documents based on a list of keys
+        /// </summary>
+        /// <typeparam name="T">Type of the items being filtered</typeparam>
+        /// <param name="items">Items being filtered</param>
+        /// <param name="keys">Keys to be selected</param>
+        /// <returns>Modified IQueryable</returns>
+        public static IQueryable<T> UseKeys<T>(
+            this IQueryable<T> items,
+            IEnumerable<string> keys)
+        {
+            if (items == null)
+            {
+                throw new ArgumentNullException("items");
+            }
+            if (keys == null)
+            {
+                throw new ArgumentNullException("keys");
+            }
+
+            if (items is EnumerableQuery<T>)
+            {
+                // If outer is an IEnumerable converted to IQueryable via AsQueryable
+                // Then we need to just call the IEnumerable implementation
+
+                if (!typeof(IDocumentMetadataProvider).IsAssignableFrom(typeof(T)))
+                {
+                    throw new NotSupportedException("Items Sequence Must Implement IDocumentMetadataProvider To Function With EnumerableQuery<T>");
+                }
+
+                var methodCall =
+                    Expression.Call(
+                        typeof(EnumerableExtensions).GetMethod("UseKeys")
+                            .MakeGenericMethod(typeof(T)),
+                        Expression.Constant(items, typeof(IEnumerable<T>)),
+                        Expression.Constant(keys, typeof(IEnumerable<string>)));
+
+                return items.Provider.CreateQuery<T>(
+                    Expression.Call(
+                        typeof(Queryable).GetMethods().First(p => p.Name == "AsQueryable" && p.GetGenericArguments().Length == 1)
+                            .MakeGenericMethod(typeof(T)),
+                        methodCall));
+            }
+            else
+            {
+                return items.Provider.CreateQuery<T>(
+                    Expression.Call(
+                        typeof(QueryExtensions).GetMethod("UseKeys")
+                            .MakeGenericMethod(typeof(T)),
+                        items.Expression,
+                        GetSourceExpression(keys)));
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// The EXPLAIN statement is used before any N1QL statement to obtain information about how the statement operates.
+        /// </summary>
+        /// <typeparam name="T">The target type.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <returns>Explanation of the query</returns>
+        public static dynamic Explain<T>(this IQueryable<T> source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+
+            var newExpression = Expression.Call(null,
+                typeof(QueryExtensions).GetMethod("Explain")
+                    .MakeGenericMethod(typeof (T)),
+                source.Expression);
+
+            return source.Provider.Execute<dynamic>(newExpression);
+        }
+
+        #region Use Index
+
+        private static readonly MethodInfo UseIndexMethod =
+            typeof(QueryExtensions).GetMethods()
+            .First(p => p.Name == "UseIndex" && p.GetParameters().Length == 3);
+
+        /// <summary>
+        /// Provides an index hint to the query engine.
+        /// </summary>
+        /// <typeparam name="T">Type of items being queried.</typeparam>
+        /// <param name="source">Items being queried.</param>
+        /// <param name="indexName">Name of the index to use.</param>
+        /// <returns>Modified IQueryable</returns>
+        public static IQueryable<T> UseIndex<T>(this IQueryable<T> source, string indexName)
+        {
+            return source.UseIndex(indexName, N1QlIndexType.Gsi);
+        }
+
+        /// <summary>
+        /// Provides an index hint to the query engine.
+        /// </summary>
+        /// <typeparam name="T">Type of items being queried.</typeparam>
+        /// <param name="source">Items being queried.</param>
+        /// <param name="indexName">Name of the index to use.</param>
+        /// <param name="indexType">Type of the index to use.</param>
+        /// <returns>Modified IQueryable</returns>
+        public static IQueryable<T> UseIndex<T>(this IQueryable<T> source, string indexName, N1QlIndexType indexType)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+            if (!Enum.IsDefined(typeof(N1QlIndexType), indexType))
+            {
+                throw new ArgumentOutOfRangeException("indexType");
+            }
+
+            return source.Provider.CreateQuery<T>(
+                    Expression.Call(
+                        UseIndexMethod
+                            .MakeGenericMethod(typeof(T)),
+                        source.Expression,
+                        Expression.Constant(indexName),
+                        Expression.Constant(indexType)));
+        }
+
+        #endregion
+
+        #region Use Hash
+
+        private static readonly MethodInfo UseHashMethod =
+            typeof(QueryExtensions).GetMethod("UseHash");
+
+        /// <summary>
+        /// Provides an hash join hint to the query engine.
+        /// </summary>
+        /// <typeparam name="T">Type of items being queried.</typeparam>
+        /// <param name="source">Items being queried.</param>
+        /// <param name="type">Type of hash hint to provide.</param>
+        /// <returns>Modified IQueryable</returns>
+        /// <remarks>Only valid when using Couchbase Server 5.5 Enterprise Edition (or later).  Not supported by Community Edition.</remarks>
+        public static IQueryable<T> UseHash<T>(this IQueryable<T> source, HashHintType type)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (!Enum.IsDefined(typeof(HashHintType), type))
+            {
+                throw new ArgumentOutOfRangeException(nameof(type));
+            }
+
+            return source.Provider.CreateQuery<T>(
+                    Expression.Call(
+                        UseHashMethod
+                            .MakeGenericMethod(typeof(T)),
+                        source.Expression,
+                        Expression.Constant(type)));
+        }
+
+        #endregion
+
+        #region Async
+
+        /// <summary>
+        /// Execute a Couchbase query asynchronously.
+        /// </summary>
+        /// <typeparam name="T">Type being queried.</typeparam>
+        /// <param name="source">Query to execute asynchronously.  Must be a Couchbase LINQ query.</param>
+        /// <returns>Task which contains the query result when completed.</returns>
+        /// <example>
+        /// var results = await query.ExecuteAsync();
+        /// </example>
+        public static Task<IEnumerable<T>> ExecuteAsync<T>(this IQueryable<T> source)
+        {
+            return source.ExecuteAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Execute a Couchbase query asynchronously.
+        /// </summary>
+        /// <typeparam name="T">Type being queried.</typeparam>
+        /// <param name="source">Query to execute asynchronously.  Must be a Couchbase LINQ query.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Task which contains the query result when completed.</returns>
+        /// <example>
+        /// var results = await query.ExecuteAsync(cancellationTokenSource.Token);
+        /// </example>
+        public static async Task<IEnumerable<T>> ExecuteAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken)
+        {
+            if (source is EnumerableQuery)
+            {
+                // Allow ExecuteAsync to simply run synchronously when executed against an in-memory collection
+                // This supports injecting mock IBucketContext instances into unit tests of business logic
+                // https://github.com/couchbaselabs/Linq2Couchbase/issues/191
+
+                return source.AsEnumerable();
+            }
+
+            EnsureBucketQueryable(source, "ExecuteAsync", "source");
+
+            var queryRequest = LinqQueryRequest.CreateQueryRequest(source);
+
+            return await
+                ((IBucketQueryExecutorProvider)source).BucketQueryExecutor.ExecuteCollectionAsync<T>(queryRequest, cancellationToken)
+                    .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Execute a Couchbase query asynchronously.
+        /// </summary>
+        /// <typeparam name="T">Type being queried.</typeparam>
+        /// <typeparam name="TResult">Type returned by <paramref name="additionalExpression"/>.</typeparam>
+        /// <param name="source">Query to execute asynchronously.  Must be a Couchbase LINQ query.</param>
+        /// <param name="additionalExpression">Additional expressions to apply to the query before executing.  Typically used for aggregates.</param>
+        /// <returns>Task which contains the query result when completed.</returns>
+        /// <remarks>
+        /// <para>The expression contained in <paramref name="additionalExpression"/> is applied to the query before
+        /// it is executed asynchrounously.  Typically, this would be used to apply an aggregate, First, Single,
+        /// or other operation to the query that normall  triggers immediate query execution.  Passing these actions
+        /// in <paramref name="additionalExpression"/> delays their execution so that they can be handled asynchronously.</para>
+        /// <para><paramref name="additionalExpression"/> must return a scalar value or a single object.  It should not return another
+        /// instance of <see cref="IQueryable{T}"/>.</para>
+        /// </remarks>
+        /// <example>
+        /// var document = await query.ExecuteAsync(query => query.First());
+        /// </example>
+        /// <example>
+        /// var avg = await query.ExecuteAsync(query => query.Average(p => p.Abv));
+        /// </example>
+        public static Task<TResult> ExecuteAsync<T, TResult>(this IQueryable<T> source,
+            Expression<Func<IQueryable<T>, TResult>> additionalExpression)
+        {
+            return source.ExecuteAsync(additionalExpression, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Execute a Couchbase query asynchronously.
+        /// </summary>
+        /// <typeparam name="T">Type being queried.</typeparam>
+        /// <typeparam name="TResult">Type returned by <paramref name="additionalExpression"/>.</typeparam>
+        /// <param name="source">Query to execute asynchronously.  Must be a Couchbase LINQ query.</param>
+        /// <param name="additionalExpression">Additional expressions to apply to the query before executing.  Typically used for aggregates.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Task which contains the query result when completed.</returns>
+        /// <remarks>
+        /// <para>The expression contained in <paramref name="additionalExpression"/> is applied to the query before
+        /// it is executed asynchrounously.  Typically, this would be used to apply an aggregate, First, Single,
+        /// or other operation to the query that normall  triggers immediate query execution.  Passing these actions
+        /// in <paramref name="additionalExpression"/> delays their execution so that they can be handled asynchronously.</para>
+        /// <para><paramref name="additionalExpression"/> must return a scalar value or a single object.  It should not return another
+        /// instance of <see cref="IQueryable{T}"/>.</para>
+        /// </remarks>
+        /// <example>
+        /// var document = await query.ExecuteAsync(query => query.First());
+        /// </example>
+        /// <example>
+        /// var avg = await query.ExecuteAsync(query => query.Average(p => p.Abv), cancellationTokenSource.Token);
+        /// </example>
+        public static async Task<TResult> ExecuteAsync<T, TResult>(this IQueryable<T> source,
+            Expression<Func<IQueryable<T>, TResult>> additionalExpression, CancellationToken cancellationToken)
+        {
+            if (source is EnumerableQuery)
+            {
+                // Allow ExecuteAsync to simply run synchronously when executed against an in-memory collection
+                // This supports injecting mock IBucketContext instances into unit tests of business logic
+                // https://github.com/couchbaselabs/Linq2Couchbase/issues/191
+
+                var additionalFunction = additionalExpression.Compile();
+                return additionalFunction(source);
+            }
+
+            EnsureBucketQueryable(source, "ExecuteAsync", "source");
+
+            if (typeof (TResult).GetTypeInfo().IsGenericTypeDefinition &&
+                (typeof (TResult).GetGenericTypeDefinition() == typeof (IQueryable<>)))
+            {
+                throw new ArgumentException("additionalExpression must return a scalar value, not IQueryable.", nameof(additionalExpression));
+            }
+
+            var queryRequest = LinqQueryRequest.CreateQueryRequest(source, additionalExpression);
+
+            return await
+                ((IBucketQueryExecutorProvider)source).BucketQueryExecutor.ExecuteSingleAsync<TResult>(queryRequest, cancellationToken)
+                    .ConfigureAwait(false);
+        }
+
+        #endregion
+
+        #region Query Request Settings
+
+        /// <summary>
+        /// Specifies the consistency guarantee/constraint for index scanning.
+        /// </summary>
+        /// <param name="source">Sets scan consistency for this query.  Must be a Couchbase LINQ query.</param>
+        /// <param name="scanConsistency">Specify the consistency guarantee/constraint for index scanning.</param>
+        /// <remarks>The default is <see cref="ScanConsistency.NotBounded"/>.</remarks>
+        public static IQueryable<T> ScanConsistency<T>(this IQueryable<T> source, ScanConsistency scanConsistency)
+        {
+            EnsureBucketQueryable(source, "ScanConsistency", "source");
+
+            ((IBucketQueryExecutorProvider) source).BucketQueryExecutor.ScanConsistency = scanConsistency;
+
+            return source;
+        }
+
+        /// <summary>
+        /// Specifies the maximum time the client is willing to wait for an index to catch up to the consistency requirement in the request.
+        /// If an index has to catch up, and the time is exceed doing so, an error is returned.
+        /// </summary>
+        /// <param name="source">Sets scan wait for this query.  Must be a Couchbase LINQ query.</param>
+        /// <param name="scanWait">The maximum time the client is willing to wait for index to catch up to the vector timestamp.</param>
+        public static IQueryable<T> ScanWait<T>(this IQueryable<T> source, TimeSpan scanWait)
+        {
+            EnsureBucketQueryable(source, "ScanWait", "source");
+
+            ((IBucketQueryExecutorProvider)source).BucketQueryExecutor.ScanWait = scanWait;
+
+            return source;
+        }
+
+        /// <summary>
+        /// Requires that the indexes but up to date with a <see cref="MutationState"/> before the query is executed.
+        /// </summary>
+        /// <param name="source">Sets consistency requirement for this query.  Must be a Couchbase LINQ query.</param>
+        /// <param name="state"><see cref="MutationState"/> used for conistency controls.</param>
+        /// <remarks>If called multiple times, the states from the calls are combined.</remarks>
+        public static IQueryable<T> ConsistentWith<T>(this IQueryable<T> source, MutationState state)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+            if (!(source is IBucketQueryExecutorProvider))
+            {
+                // do nothing if this isn't a Couchbase LINQ query
+                return source;
+            }
+
+            ((IBucketQueryExecutorProvider) source).BucketQueryExecutor.ConsistentWith(state);
+
+            return source;
+        }
+
+        /// <summary>
+        /// Specifies if the query results should be streamed, reducing memory utilzation for large result sets.
+        /// </summary>
+        /// <param name="source">Sets scan consistency for this query.  Must be a Couchbase LINQ query.</param>
+        /// <param name="useStreaming">Specifies if query results should be streamed.</param>
+        /// <remarks>
+        /// Streaming is not supported in combination with change tracking.  If change tracking is enabled,
+        /// this setting will be ignored.  Streaming is disabled by default.
+        /// </remarks>
+        public static IQueryable<T> UseStreaming<T>(this IQueryable<T> source, bool useStreaming)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+            if (!(source is IBucketQueryExecutorProvider))
+            {
+                // do nothing if this isn't a Couchbase LINQ query
+                return source;
+            }
+
+            ((IBucketQueryExecutorProvider)source).BucketQueryExecutor.UseStreaming = useStreaming;
+
+            return source;
+        }
+
+        #endregion
+
+        private static void EnsureBucketQueryable<T>(IQueryable<T> source, string methodName, string paramName)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+            if (!(source is IBucketQueryable) || !(source is IBucketQueryExecutorProvider))
+            {
+                throw new ArgumentException(string.Format("{0} is only supported on Couchbase LINQ queries.", methodName), paramName);
+            }
+        }
+
+        /// <summary>
+        /// An expression generation helper for adding additional methods to a Linq provider.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TR">The type of the return value.</typeparam>
+        /// <param name="source">The <see cref="IQueryable"/> source.</param>
+        /// <param name="expression">The expression.</param>
+        /// <remarks>Original work from: https://www.re-motion.org/blogs/mix/2010/10/28/re-linq-extensibility-custom-query-operators.</remarks>
+        /// <returns></returns>
+        private static IQueryable<T> CreateQuery<T, TR>(
+            this IQueryable<T> source, Expression<Func<IQueryable<T>, TR> > expression)
+        {
+            var queryExpression = ReplacingExpressionVisitor.Replace(
+                expression.Parameters[0],
+                source.Expression,
+                expression.Body);
+
+            return source.Provider.CreateQuery<T>(queryExpression);
+        }
+
+        private static Expression GetSourceExpression<TSource>(IEnumerable<TSource> source)
+        {
+            IQueryable<TSource> q = source as IQueryable<TSource>;
+            if (q != null) return q.Expression;
+            return Expression.Constant(source, typeof(IEnumerable<TSource>));
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Filters/AttributeDocumentFilterSetGenerator.cs
+++ b/src/Couchbase.EntityFramework/Filters/AttributeDocumentFilterSetGenerator.cs
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.Filters
+{
+    /// <summary>
+    /// Generates an <see cref="DocumentFilterSet{T}">DocumentFilterSet</see> for a particular type, using <see cref="DocumentFilterAttribute">DocumentFilterAttributes</see>
+    /// </summary>
+    public class AttributeDocumentFilterSetGenerator : IDocumentFilterSetGenerator
+    {
+
+        /// <summary>
+        /// Generates an <see cref="DocumentFilterSet{T}">DocumentFilterSet</see> for a particular type, using <see cref="DocumentFilterAttribute">DocumentFilterAttribute</see>s
+        /// </summary>
+        /// <returns>Returns null if there are no filters.  This is to improve efficieny.</returns>
+        public DocumentFilterSet<T> GenerateDocumentFilterSet<T>()
+        {
+            var filters = (DocumentFilterAttribute[])typeof(T).GetTypeInfo().GetCustomAttributes(typeof (DocumentFilterAttribute), true);
+
+            if (filters.Length == 0)
+            {
+                return null;
+            }
+            else 
+            {
+                return new DocumentFilterSet<T>(filters.Select(p => p.GetFilter<T>()));
+            }
+        }
+
+    }
+}

--- a/src/Couchbase.EntityFramework/Filters/DocumentFilterAttribute.cs
+++ b/src/Couchbase.EntityFramework/Filters/DocumentFilterAttribute.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Couchbase.EntityFramework.Filters
+{
+    /// <summary>
+    /// Abstract base class for attribute-based <see cref="IDocumentFilter{T}">IDocumentFilter</see> implementations
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public abstract class DocumentFilterAttribute : Attribute
+    {
+        /// <summary>
+        /// Priority of this filter compared to other filters against the same type.  Lower priorities execute first.
+        /// </summary>
+        public int Priority { get; set; }
+
+        /// <summary>
+        /// Returns the <see cref="IDocumentFilter{T}"/> to be applied by this attribute.
+        /// </summary>
+        /// <typeparam name="T">Type of the document being filtered.</typeparam>
+        /// <returns>The <see cref="IDocumentFilter{T}"/> to be applied by this attribute.</returns>
+        public abstract IDocumentFilter<T> GetFilter<T>();
+
+    }
+}

--- a/src/Couchbase.EntityFramework/Filters/DocumentFilterManager.cs
+++ b/src/Couchbase.EntityFramework/Filters/DocumentFilterManager.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Couchbase.EntityFramework.Filters
+{
+    /// <summary>
+    /// Static class to cache and execute <see cref="IDocumentFilter{T}">IDocumentFilter</see> objects based on the type being queried
+    /// </summary>
+    public class DocumentFilterManager
+    {
+
+        /// <summary>
+        /// Stores currently loaded filters.
+        /// </summary>
+        /// <remarks>
+        /// Any type which has no filters will be in the dictionary, with a value of null.  This will prevent another attempt
+        /// to generate the default <see cref="DocumentFilterSet{T}">DocumentFilterSet</see> each time it is requested.
+        /// </remarks>
+        private static readonly Dictionary<Type, object> Filters = new Dictionary<Type, object>();
+
+        private static IDocumentFilterSetGenerator _filterSetGenerator = new AttributeDocumentFilterSetGenerator();
+        /// <summary>
+        /// Generates the <see cref="DocumentFilterSet{T}">DocumentFilterSet</see> for a type if no filters have been previously loaded
+        /// </summary>
+        /// <remarks>By default, uses an <see cref="AttributeDocumentFilterSetGenerator">AttributeDocumentFeatureSetGenerator</see></remarks>
+        public static IDocumentFilterSetGenerator FilterSetGenerator
+        {
+            get { return _filterSetGenerator; }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+
+                _filterSetGenerator = value;
+            }
+        }
+
+        /// <summary>
+        /// Returns the filter set for a type, creating a new filters set using the <see cref="FilterSetGenerator">FilterSetGenerator</see> if there is no key in the Filters dictionary.
+        /// </summary>
+        /// <returns>Returns null if there are no filters defined for this type</returns>
+        public static DocumentFilterSet<T> GetFilterSet<T>()
+        {
+            object filterSet;
+            lock (Filters)
+            {
+                if (!Filters.TryGetValue(typeof(T), out filterSet))
+                {
+                    filterSet = FilterSetGenerator.GenerateDocumentFilterSet<T>();
+                    Filters.Add(typeof(T), filterSet);
+                }
+            }
+
+            return (DocumentFilterSet<T>)filterSet;
+        }
+
+        /// <summary>
+        /// Add or change filter, replacing the entire filter set if present
+        /// </summary>
+        public static void SetFilter<T>(IDocumentFilter<T> filter)
+        {
+            if (filter == null)
+            {
+                throw new ArgumentNullException("filter");
+            }
+
+            lock (Filters)
+            {
+                Filters[typeof(T)] = new DocumentFilterSet<T>(filter);
+            }
+        }
+
+        /// <summary>
+        /// Add or change a filter set
+        /// </summary>
+        public static void SetFilterSet<T>(DocumentFilterSet<T> filterSet)
+        {
+            if (filterSet == null)
+            {
+                throw new ArgumentNullException("filterSet");
+            }
+
+            lock (Filters)
+            {
+                Filters[typeof(T)] = filterSet;
+            }
+        }
+
+        /// <summary>
+        /// Remove a filter set.
+        /// </summary>
+        public static void RemoveFilterSet<T>()
+        {
+
+            lock (Filters)
+            {
+                Filters[typeof(T)] = null;
+            }
+        }
+
+        /// <summary>
+        /// Clear all filter sets.
+        /// </summary>
+        /// <remarks>Will cause future requests to be regenerated using the <see cref="FilterSetGenerator">FilterSetGenerator</see>.</remarks>
+        public static void Clear()
+        {
+            lock (Filters)
+            {
+                Filters.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Apply filters to a LINQ query
+        /// </summary>
+        public static IQueryable<T> ApplyFilters<T>(IQueryable<T> source)
+        {
+            var filterSet = GetFilterSet<T>();
+
+            if (filterSet != null)
+            {
+                return filterSet.ApplyFilters(source);
+            }
+            else
+            {
+                return source;
+            }
+        }
+
+    }
+}

--- a/src/Couchbase.EntityFramework/Filters/DocumentFilterSet.cs
+++ b/src/Couchbase.EntityFramework/Filters/DocumentFilterSet.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Couchbase.EntityFramework.Filters
+{
+    /// <summary>
+    /// Stores a list of <see cref="IDocumentFilter{T}">IDocumentFilter</see>s, sorted by Priority
+    /// </summary>
+    /// <remarks>
+    /// Sort order of IDocumentFilters with the same Priority is undefined
+    /// </remarks>
+    public class DocumentFilterSet<T> : SortedSet<IDocumentFilter<T>>
+    {
+
+        /// <summary>
+        /// Create an empty DocumentFilterSet
+        /// </summary>
+        public DocumentFilterSet() : base(new PriorityComparer())
+        {
+        }
+
+        /// <summary>
+        /// Create an DocumentFilterSet, filled with a set of filters
+        /// </summary>
+        public DocumentFilterSet(IEnumerable<IDocumentFilter<T>> filters) : base(filters, new PriorityComparer())
+        {   
+        }
+
+        /// <summary>
+        /// Create an DocumentFilterSet, filled with a set of filters
+        /// </summary>
+        public DocumentFilterSet(params IDocumentFilter<T>[] filters)
+            : base(filters, new PriorityComparer())
+        {
+        }
+
+        /// <summary>
+        /// Apply the filters to a LINQ query, in order
+        /// </summary>
+        public IQueryable<T> ApplyFilters(IQueryable<T> source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+
+            foreach (var filter in this)
+            {
+                source = filter.ApplyFilter(source);
+            }
+
+            return source;
+        }
+
+        private class PriorityComparer : IComparer<IDocumentFilter<T>>
+        {
+
+            public int Compare(IDocumentFilter<T> x, IDocumentFilter<T> y)
+            {
+                return x.Priority.CompareTo(y.Priority);
+            }
+
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Filters/DocumentTypeFilterAttribute.cs
+++ b/src/Couchbase.EntityFramework/Filters/DocumentTypeFilterAttribute.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Couchbase.EntityFramework.Filters
+{
+    /// <summary>
+    /// When using Linq2Couchbase, automatically filter returned documents by the "type" attribute
+    /// </summary>
+    public class DocumentTypeFilterAttribute : DocumentFilterAttribute
+    {
+        /// <summary>
+        /// Filter the results to include documents with this string as the "type" attribute
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Creates a new DocumentTypeFilterAttribute
+        /// </summary>
+        /// <param name="type">Filter the results to include documents with this string as the "type" attribute</param>
+        public DocumentTypeFilterAttribute(string type)
+        {
+            Type = type;
+        }
+
+        /// <summary>
+        /// Apply the filter to a LINQ query
+        /// </summary>
+        public override IDocumentFilter<T> GetFilter<T>()
+        {
+            return new WhereFilter<T>
+            {
+                Priority = Priority,
+                WhereExpression = GetExpression<T>()
+            };
+        }
+
+        private Expression<Func<T, bool>> GetExpression<T>()
+        {
+            var parameter = Expression.Parameter(typeof (T), "p");
+
+            return Expression.Lambda<Func<T, bool>>(Expression.Equal(Expression.PropertyOrField(parameter, "type"), Expression.Constant(Type)), parameter);
+        }
+
+        private class WhereFilter<T> : IDocumentFilter<T>
+        {
+            public Expression<Func<T, bool>> WhereExpression { get; set; }
+            public int Priority { get; set; }
+
+            public IQueryable<T> ApplyFilter(IQueryable<T> source)
+            {
+                return source.Where(WhereExpression);
+            }
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Filters/IDocumentFilter.cs
+++ b/src/Couchbase.EntityFramework/Filters/IDocumentFilter.cs
@@ -1,0 +1,20 @@
+﻿using System.Linq;
+
+namespace Couchbase.EntityFramework.Filters
+{
+    /// <summary>
+    /// Filter designed to be applied to a LINQ query automatically
+    /// </summary>
+    public interface IDocumentFilter<T>
+    {
+        /// <summary>
+        /// Priority of this filter compared to other filters against the same type.  Lower priorities execute first.
+        /// </summary>
+        int Priority { get; set; }
+
+        /// <summary>
+        /// Apply the filter to a LINQ query
+        /// </summary>
+        IQueryable<T> ApplyFilter(IQueryable<T> source);
+    }
+}

--- a/src/Couchbase.EntityFramework/Filters/IDocumentFilterSetGenerator.cs
+++ b/src/Couchbase.EntityFramework/Filters/IDocumentFilterSetGenerator.cs
@@ -1,0 +1,16 @@
+﻿namespace Couchbase.EntityFramework.Filters
+{
+    /// <summary>
+    /// Generates an <see cref="DocumentFilterSet&lt;T&gt;">DocumentFilterSet</see> for a particular type.
+    /// </summary>
+    public interface IDocumentFilterSetGenerator
+    {
+
+        /// <summary>
+        /// Generates an <see cref="DocumentFilterSet&lt;T&gt;">DocumentFilterSet</see> for a particular type.
+        /// </summary>
+        /// <returns>Returns null if there are no filters.  This is to improve efficieny.</returns>
+        DocumentFilterSet<T> GenerateDocumentFilterSet<T>();
+
+    }
+}

--- a/src/Couchbase.EntityFramework/HashHintType.cs
+++ b/src/Couchbase.EntityFramework/HashHintType.cs
@@ -1,0 +1,8 @@
+﻿namespace Couchbase.EntityFramework
+{
+    public enum HashHintType
+    {
+        Build = 0,
+        Probe = 1
+    }
+}

--- a/src/Couchbase.EntityFramework/IBucketContext.cs
+++ b/src/Couchbase.EntityFramework/IBucketContext.cs
@@ -1,0 +1,113 @@
+﻿using System.Linq;
+using Couchbase.Configuration.Client;
+using Couchbase.Core;
+using Couchbase.EntityFramework.Extensions;
+using Couchbase.Linq;
+using Couchbase.N1QL;
+
+namespace Couchbase.EntityFramework
+{
+    /// <summary>
+    /// Provides a single point of entry to a Couchbase bucket which makes it easier to compose
+    /// and execute queries and to group togather changes which will be submitted back into the bucket.
+    /// </summary>
+    public interface IBucketContext : IBucketQueryable
+    {
+        /// <summary>
+        /// Gets the bucket the <see cref="IBucketContext"/> was created against.
+        /// </summary>
+        /// <value>The <see cref="IBucket"/>.</value>
+        IBucket Bucket { get; }
+
+        /// <summary>
+        /// Gets the configuration for the current <see cref="Cluster"/>.
+        /// </summary>
+        /// <value>
+        /// The configuration.
+        /// </value>
+        ClientConfiguration Configuration { get; }
+
+        /// <summary>
+        /// Begins change tracking for the current request. To complete and save the changes call <see cref="SubmitChanges()"/>.
+        /// </summary>
+        void BeginChangeTracking();
+
+        /// <summary>
+        /// Ends change tracking on the current context.
+        /// </summary>
+        void EndChangeTracking();
+
+        /// <summary>
+        /// Submits the changes.
+        /// </summary>
+        void SubmitChanges();
+
+        /// <summary>
+        /// Submits the changes with options.
+        /// </summary>
+        /// <param name="options">Options to control how changes are submitted.</param>
+        void SubmitChanges(SaveOptions options);
+
+        /// <summary>
+        /// Queries the current <see cref="IBucket" /> for entities of type T. This is the target of
+        /// a LINQ query and requires that the associated JSON document have a type property that is the same as T.
+        /// </summary>
+        /// <typeparam name="T">An entity or POCO representing the object graph of a JSON document.</typeparam>
+        /// <returns><see cref="IQueryable{T}" /> which can be used to query the bucket.</returns>
+        IQueryable<T> Query<T>();
+
+        /// <summary>
+        /// Queries the current <see cref="IBucket" /> for entities of type T. This is the target of
+        /// a LINQ query and requires that the associated JSON document have a type property that is the same as T.
+        /// </summary>
+        /// <typeparam name="T">An entity or POCO representing the object graph of a JSON document.</typeparam>
+        /// <param name="options">Options to control the returned query.</param>
+        /// <returns><see cref="IQueryable{T}" /> which can be used to query the bucket.</returns>
+        IQueryable<T> Query<T>(BucketQueryOptions options);
+
+        /// <summary>
+        /// Saves the specified document.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="document">The document.</param>
+        void Save<T>(T document);
+
+        /// <summary>
+        /// Removes the specified document.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="document">The document.</param>
+        void Remove<T>(T document);
+
+        /// <summary>
+        /// If true, generate change tracking proxies for documents during deserialization. Defaults to false for higher performance queries.
+        /// </summary>
+        bool ChangeTrackingEnabled { get; }
+
+        #region Mutation State
+
+        /// <summary>
+        /// The current <see cref="N1QL.MutationState"/>.  May return null if there
+        /// have been no mutations.
+        /// </summary>
+        /// <remarks>
+        /// This value is updated as mutations are applied via <see cref="Save{T}"/>.  It may be used
+        /// to enable read-your-own-write by passing the value to <see cref="QueryExtensions.ConsistentWith{T}"/>.
+        /// If you are using change tracking, this value won't be valid until after a call to <see cref="SubmitChanges()"/>.
+        /// This function is only supported on Couchbase Server 4.5 or later.
+        /// </remarks>
+        MutationState MutationState { get; }
+
+        /// <summary>
+        /// Resets the <see cref="MutationState"/> to start a new set of mutations.
+        /// </summary>
+        /// <remarks>
+        /// If you are using an <see cref="IBucketContext"/> over and extended period of time,
+        /// performing a reset regularly is recommend.  This will help keep the size of the
+        /// <see cref="MutationState"/> to a minimum.
+        /// </remarks>
+        void ResetMutationState();
+
+        #endregion
+    }
+}

--- a/src/Couchbase.EntityFramework/IBucketQueryable.cs
+++ b/src/Couchbase.EntityFramework/IBucketQueryable.cs
@@ -1,0 +1,22 @@
+﻿using System.Linq;
+
+namespace Couchbase.EntityFramework
+{
+    /// <summary>
+    /// IQueryable sourced from a Couchbase bucket.  Used to provide the bucket name to the query generator.
+    /// </summary>
+    public interface IBucketQueryable
+    {
+        /// <summary>
+        /// Bucket query is run against
+        /// </summary>
+        string BucketName { get; }
+    }
+
+    /// <summary>
+    /// IQueryable sourced from a Couchbase bucket.  Used to provide the bucket name to the query generator.
+    /// </summary>
+    public interface IBucketQueryable<out T> : IQueryable<T>, IBucketQueryable
+    {
+    }
+}

--- a/src/Couchbase.EntityFramework/IChangeTrackableContext.cs
+++ b/src/Couchbase.EntityFramework/IChangeTrackableContext.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Couchbase.EntityFramework.Proxies;
+
+namespace Couchbase.EntityFramework
+{
+    /// <summary>
+    /// Provides an interface for supporting persistence of documents via proxies when change tracking is enabled.
+    /// </summary>
+    internal interface IChangeTrackableContext : ITrackedDocumentNodeCallback
+    {
+        /// <summary>
+        /// Adds a document to the list of tracked documents if change tracking is enabled.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> of the document to track.</typeparam>
+        /// <param name="document">The object representing the document.</param>
+        void Track<T>(T document);
+
+        /// <summary>
+        /// Removes a document from the list if tracked documents.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="document"></param>
+        void Untrack<T>(T document);
+
+        /// <summary>
+        /// Adds a document to the list of modified documents if it is has been mutated and is being tracked.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="document"></param>
+        void Modified<T>(T document);
+
+        /// <summary>
+        /// The count of documents that have been modified if change tracking is enabled.
+        /// </summary>
+        int ModifiedCount { get; }
+
+        /// <summary>
+        /// The count of all documents currently being tracked.
+        /// </summary>
+        int TrackedCount { get; }
+    }
+}

--- a/src/Couchbase.EntityFramework/Metadata/DocumentMetadata.cs
+++ b/src/Couchbase.EntityFramework/Metadata/DocumentMetadata.cs
@@ -1,0 +1,45 @@
+﻿using Newtonsoft.Json;
+
+namespace Couchbase.EntityFramework.Metadata
+{
+    /// <summary>
+    /// Metadata about a document in Couchbase
+    /// </summary>
+    public class DocumentMetadata
+    {
+        /// <summary>
+        /// "Compare and swap" value.  This value changes each time the document is mutated.
+        /// This can be used to ensure that the document has not been modified
+        /// during a mutation, which enforces optimistic concurrency.
+        /// </summary>
+        [JsonProperty("cas")]
+        public double Cas { get; set; }
+
+        /// <summary>
+        /// SDK specific flags.
+        /// </summary>
+        [JsonProperty("flags")]
+        public int Flags { get; set; }
+
+        /// <summary>
+        /// Document's unique ID.  Also referred to as the document key.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Information about the type of the document.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Returns the JSON string representation of this object.
+        /// </summary>
+        /// <returns>JSON string representation of this object.</returns>
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Metadata/IDocumentMetadataProvider.cs
+++ b/src/Couchbase.EntityFramework/Metadata/IDocumentMetadataProvider.cs
@@ -1,0 +1,22 @@
+﻿using Couchbase.Linq;
+
+namespace Couchbase.EntityFramework.Metadata
+{
+    /// <summary>
+    /// Returns metadata about the document object the interface is attached to
+    /// </summary>
+    /// <remarks>
+    /// Used by a unit test to fake the results of a META operation in a Linq2Couchbase query
+    /// </remarks>
+    /// <seealso cref="N1QlFunctions.Meta" />
+    public interface IDocumentMetadataProvider
+    {
+
+        /// <summary>
+        /// Get metadata about this document
+        /// </summary>
+        /// <returns>Metadata about this document</returns>
+        DocumentMetadata GetMetadata();
+
+    }
+}

--- a/src/Couchbase.EntityFramework/N1QlDatePart.cs
+++ b/src/Couchbase.EntityFramework/N1QlDatePart.cs
@@ -1,0 +1,138 @@
+﻿using System.Runtime.Serialization;
+using Couchbase.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Couchbase.EntityFramework
+{
+    /// <summary>
+    /// Represents date parts for calls to date related <see cref="N1QlFunctions"/>.
+    /// </summary>
+    /// <remarks>
+    /// Different date related functions are compatible with different date parts.
+    /// For details, see the N1QL documentation.
+    /// </remarks>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum N1QlDatePart
+    {
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "millennium")]
+        Millennium,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "century")]
+        Century,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "decade")]
+        Decade,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "year")]
+        Year,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "quarter")]
+        Quarter,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "month")]
+        Month,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "week")]
+        Week,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "day")]
+        Day,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "hour")]
+        Hour,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "minute")]
+        Minute,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "second")]
+        Second,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "millisecond")]
+        Millisecond,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "doy")]
+        DayOfYear,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "dow")]
+        DayOfWeek,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "iso_week")]
+        IsoWeek,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "iso_year")]
+        IsoYear,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "iso_dow")]
+        IsoDayOfWeek,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "timezone")]
+        TimeZone,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "timezone_hour")]
+        TimeZoneOffsetHour,
+
+        /// <summary>
+        /// See N1QL documentation.
+        /// </summary>
+        [EnumMember(Value = "timezone_minute")]
+        TimeZoneOffsetMinute
+    }
+}

--- a/src/Couchbase.EntityFramework/N1QlFunctionAttribute.cs
+++ b/src/Couchbase.EntityFramework/N1QlFunctionAttribute.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace Couchbase.EntityFramework
+{
+    /// <summary>
+    /// Decorates a method that is converted to a N1QL function call.  Each parameter in .Net
+    /// is expected to correspond directly to a parameter in N1QL, in the same order.
+    /// </summary>
+    /// <remarks>
+    /// Should only be used to decorate static methods.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Method)]
+    internal class N1QlFunctionAttribute : Attribute
+    {
+        /// <summary>
+        /// Name of the function in N1QL.
+        /// </summary>
+        public string N1QlFunctionName { get; set; }
+
+        /// <summary>
+        /// Creates a new N1QlFunctionAttribute.
+        /// </summary>
+        /// <param name="n1QlFunctionName">Name of the function in N1QL.</param>
+        public N1QlFunctionAttribute(string n1QlFunctionName)
+        {
+            if (string.IsNullOrEmpty(n1QlFunctionName))
+            {
+                throw new ArgumentNullException("n1QlFunctionName");
+            }
+
+            N1QlFunctionName = n1QlFunctionName;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/N1QlFunctions.Core.cs
+++ b/src/Couchbase.EntityFramework/N1QlFunctions.Core.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Couchbase.EntityFramework
+{
+    /// <summary>
+    /// Implements static helper methods for N1QL queries
+    /// </summary>
+    public static partial class N1QlFunctions
+    {
+        /// <summary>
+        /// Shortcut for creating an error for methods that are only supported in N1QL, not in .Net.
+        /// </summary>
+        private static Exception NotSupportedError()
+        {
+            return new NotSupportedException("This method may only be used in lambda expressions for generating N1QL queries.");
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/N1QlFunctions.DateTime.cs
+++ b/src/Couchbase.EntityFramework/N1QlFunctions.DateTime.cs
@@ -1,0 +1,61 @@
+﻿using System;
+
+namespace Couchbase.EntityFramework
+{
+    public partial class N1QlFunctions
+    {
+        /// <summary>
+        /// Adds an interval to a date/time, where the unit of interval is part.
+        /// </summary>
+        /// <param name="date">Date/time on which to perform arithmetic.</param>
+        /// <param name="interval">Interval to add to date.</param>
+        /// <param name="part">Unit of the interval being added to date.</param>
+        /// <returns>New date/time</returns>
+        /// <remarks>Only valid for use in N1QL queries.</remarks>
+        [N1QlFunction("DATE_ADD_STR")]
+        public static DateTime DateAdd(DateTime date, long interval, N1QlDatePart part)
+        {
+            throw NotSupportedError();
+        }
+
+        /// <summary>
+        /// Returns the elapsed time between date/times as an integer whose unit is part.
+        /// </summary>
+        /// <param name="date1">Starting date/time for difference.</param>
+        /// <param name="date2">Ending date/time for difference.</param>
+        /// <param name="part">Unit of the interval to return.</param>
+        /// <returns>Difference between date1 and date2 in part units.  Result is positive if date1 is later than date2.</returns>
+        /// <remarks>Only valid for use in N1QL queries.</remarks>
+        [N1QlFunction("DATE_DIFF_STR")]
+        public static long DateDiff(DateTime date1, DateTime date2, N1QlDatePart part)
+        {
+            throw NotSupportedError();
+        }
+
+        /// <summary>
+        /// Returns the date part as an integer.
+        /// </summary>
+        /// <param name="date">Date/time to extract the part of</param>
+        /// <param name="part">Part to extract.</param>
+        /// <returns>Portion of the date/time, based on part.</returns>
+        /// <remarks>Only valid for use in N1QL queries.</remarks>
+        [N1QlFunction("DATE_PART_STR")]
+        public static long DatePart(DateTime date, N1QlDatePart part)
+        {
+            throw NotSupportedError();
+        }
+
+        /// <summary>
+        /// Truncates the given date/time so that the given date part is the least significant.
+        /// </summary>
+        /// <param name="date">Date/time to be truncated.</param>
+        /// <param name="part">Part to be the least significant.</param>
+        /// <returns>Truncated date/time.</returns>
+        /// <remarks>Only valid for use in N1QL queries.</remarks>
+        [N1QlFunction("DATE_TRUNC_STR")]
+        public static DateTime DateTrunc(DateTime date, N1QlDatePart part)
+        {
+            throw NotSupportedError();
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/N1QlFunctions.Metadata.cs
+++ b/src/Couchbase.EntityFramework/N1QlFunctions.Metadata.cs
@@ -1,0 +1,55 @@
+﻿using Couchbase.EntityFramework.Metadata;
+
+namespace Couchbase.EntityFramework
+{
+    public static partial class N1QlFunctions
+    {
+        /// <summary>
+        /// Returns metadata for a document object
+        /// </summary>
+        /// <param name="document">Document to get metadata from</param>
+        /// <returns>Metadata about the document</returns>
+        /// <remarks>Should only be called against a top-level document in Couchbase</remarks>
+        public static DocumentMetadata Meta(object document)
+        {
+            // Implementation will only be called when unit testing
+            // using LINQ-to-Objects and faking a Couchbase database
+            // Any faked document object should implement IDocumentMetadataProvider
+
+            var provider = document as IDocumentMetadataProvider;
+            if (provider != null)
+            {
+                return provider.GetMetadata();
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Returns the key for a document object
+        /// </summary>
+        /// <param name="document">Document to get key from</param>
+        /// <returns>Key of the document</returns>
+        /// <remarks>Should only be called against a top-level document in Couchbase</remarks>
+        public static string Key(object document)
+        {
+            // Implementation will only be called when unit testing
+            // using LINQ-to-Objects and faking a Couchbase database
+            // Any faked document object should implement IDocumentMetadataProvider
+
+            var provider = document as IDocumentMetadataProvider;
+            if (provider != null)
+            {
+                var metadata = provider.GetMetadata();
+
+                return metadata != null ? metadata.Id : null;
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/N1QlFunctions.Missing.cs
+++ b/src/Couchbase.EntityFramework/N1QlFunctions.Missing.cs
@@ -1,0 +1,159 @@
+﻿namespace Couchbase.EntityFramework
+{
+    public static partial class N1QlFunctions
+    {
+        #region IsMissing and IsNotMissing
+
+        /// <summary>
+        /// Returns true if the selected property is missing from the document
+        /// </summary>
+        /// <typeparam name="T">Type of the property being selected</typeparam>
+        /// <param name="property">Property to test</param>
+        /// <returns>True if the property is missing from the document</returns>
+        public static bool IsMissing<T>(T property)
+        {
+            // Implementation will only be called when unit testing
+            // Since properties cannot be missing on in-memory objects
+            // Always returns false
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true if the named property is missing from the document
+        /// </summary>
+        /// <typeparam name="T">Type of the document being tested</typeparam>
+        /// <param name="document">Document being tested</param>
+        /// <param name="propertyName">Property name to test</param>
+        /// <returns>True if the property is missing from the document</returns>
+        /// <remarks>propertyName must be a constant when used in a LINQ expression</remarks>
+        public static bool IsMissing<T>(T document, string propertyName)
+        {
+            // Implementation will only be called when unit testing
+            // Test to see if the property is present via reflection
+
+            return (document == null) || (typeof (T).GetProperty(propertyName) == null);
+        }
+
+        /// <summary>
+        /// Returns true if the selected property is present on the document
+        /// </summary>
+        /// <typeparam name="T">Type of the property being selected</typeparam>
+        /// <param name="property">Property to test</param>
+        /// <returns>True if the property is present on the document</returns>
+        public static bool IsNotMissing<T>(T property)
+        {
+            // Implementation will only be called when unit testing
+            // Since properties cannot be missing on in-memory objects
+            // Always returns true
+
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true if the named property is present on the document
+        /// </summary>
+        /// <typeparam name="T">Type of the document being tested</typeparam>
+        /// <param name="document">Document being tested</param>
+        /// <param name="propertyName">Property name to test</param>
+        /// <returns>True if the property is present on the document</returns>
+        /// <remarks>propertyName must be a constant when used in a LINQ expression</remarks>
+        public static bool IsNotMissing<T>(T document, string propertyName)
+        {
+            // Implementation will only be called when unit testing
+            // Test to see if the property is present via reflection
+
+            return (document != null) && (typeof(T).GetProperty(propertyName) != null);
+        }
+
+        #endregion
+
+        #region IsValued and IsNotValued
+
+        /// <summary>
+        /// Returns true if the selected property is present on the document and not null
+        /// </summary>
+        /// <typeparam name="T">Type of the property being selected</typeparam>
+        /// <param name="property">Property to test</param>
+        /// <returns>True if the property is present on the document and not null</returns>
+        public static bool IsValued<T>(T property)
+        {
+            // Implementation will only be called when unit testing
+            // Since properties cannot be missing on in-memory objects
+            // Simply test for null
+
+            return property != null;
+        }
+
+        /// <summary>
+        /// Returns true if the named property is not missing from the document and not null
+        /// </summary>
+        /// <typeparam name="T">Type of the document being tested</typeparam>
+        /// <param name="document">Document being tested</param>
+        /// <param name="propertyName">Property name to test</param>
+        /// <returns>True if the property is present on the document and not null</returns>
+        /// <remarks>propertyName must be a constant when used in a LINQ expression</remarks>
+        public static bool IsValued<T>(T document, string propertyName)
+        {
+            // Implementation will only be called when unit testing
+            // Test to see if the property is present and not null via reflection
+
+            if (document == null)
+            {
+                return false;
+            }
+
+            var property = typeof (T).GetProperty(propertyName);
+            if (property == null)
+            {
+                return false;
+            }
+
+            return property.GetValue(document) != null;
+        }
+
+        /// <summary>
+        /// Returns true if the selected property is missing from the document or null
+        /// </summary>
+        /// <typeparam name="T">Type of the property being selected</typeparam>
+        /// <param name="property">Property to test</param>
+        /// <returns>True if the property is missing from the document or null</returns>
+        public static bool IsNotValued<T>(T property)
+        {
+            // Implementation will only be called when unit testing
+            // Since properties cannot be missing on in-memory objects
+            // Simply test for null
+
+            return property == null;
+        }
+
+        /// <summary>
+        /// Returns true if the named property is missing from the document or null
+        /// </summary>
+        /// <typeparam name="T">Type of the document being tested</typeparam>
+        /// <param name="document">Document being tested</param>
+        /// <param name="propertyName">Property name to test</param>
+        /// <returns>True if the property is missing from the document or null</returns>
+        /// <remarks>propertyName must be a constant when used in a LINQ expression</remarks>
+        public static bool IsNotValued<T>(T document, string propertyName)
+        {
+            // Implementation will only be called when unit testing
+            // Test to see if the property is present via reflection
+
+            if (document == null)
+            {
+                return true;
+            }
+
+            var property = typeof(T).GetProperty(propertyName);
+            if (property == null)
+            {
+                return true;
+            }
+
+            return property.GetValue(document) == null;
+        }
+
+        #endregion
+    }
+}

--- a/src/Couchbase.EntityFramework/N1QlIndexType.cs
+++ b/src/Couchbase.EntityFramework/N1QlIndexType.cs
@@ -1,0 +1,20 @@
+﻿using Couchbase.EntityFramework.Extensions;
+
+namespace Couchbase.EntityFramework
+{
+    /// <summary>
+    /// Types of indices supported by N1QL query <see cref="QueryExtensions.UseIndex{T}(System.Linq.IQueryable{T},string,Couchbase.EntityFramework.N1QlIndexType)"/>.
+    /// </summary>
+    public enum N1QlIndexType
+    {
+        /// <summary>
+        /// Global secondary index
+        /// </summary>
+        Gsi,
+
+        /// <summary>
+        /// View index
+        /// </summary>
+        View
+    }
+}

--- a/src/Couchbase.EntityFramework/Operators/ExplainExpressionNode.cs
+++ b/src/Couchbase.EntityFramework/Operators/ExplainExpressionNode.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.Extensions;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.EntityFramework.Operators
+{
+    /// <summary>
+    /// Expression parser for N1QL "Explain" method.
+    /// </summary>
+    internal class ExplainExpressionNode : ResultOperatorExpressionNodeBase
+    {
+        public static MethodInfo[] SupportedMethods =
+        {
+            typeof (QueryExtensions).GetMethod("Explain")
+        };
+
+        public ExplainExpressionNode(MethodCallExpressionParseInfo parseInfo,
+            LambdaExpression optionalPredicate,
+            LambdaExpression optionalSelector)
+            : base(parseInfo, optionalPredicate, optionalSelector)
+        {
+        }
+
+        protected override ResultOperatorBase CreateResultOperator(
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return new ExplainResultOperator();
+        }
+
+        public override Expression Resolve(ParameterExpression inputParameter,
+            Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(
+                inputParameter,
+                expressionToBeResolved,
+                clauseGenerationContext);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Operators/ExplainResultOperator.cs
+++ b/src/Couchbase.EntityFramework/Operators/ExplainResultOperator.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Linq.Expressions;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.ResultOperators;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.EntityFramework.Operators
+{
+    internal class ExplainResultOperator : ValueFromSequenceResultOperatorBase
+    {
+        public override StreamedValue ExecuteInMemory<T>(StreamedSequence input)
+        {
+            throw new NotImplementedException("Cannot explain N1QL queries in memory");
+        }
+
+        public override ResultOperatorBase Clone(CloneContext cloneContext)
+        {
+            return new ExplainResultOperator();
+        }
+
+        public override IStreamedDataInfo GetOutputDataInfo(IStreamedDataInfo inputInfo)
+        {
+            if (inputInfo == null)
+            {
+                throw new ArgumentNullException("inputInfo");
+            }
+
+            var sequenceInfo = inputInfo as StreamedSequenceInfo;
+            if (sequenceInfo == null)
+            {
+                throw new ArgumentException(string.Format("Parameter 'inputInfo' has unexpected type '{0}'.", inputInfo.GetType()));
+            }
+
+            return GetOutputDataInfo(sequenceInfo);
+        }
+
+        private StreamedValueInfo GetOutputDataInfo(StreamedSequenceInfo sequenceInfo)
+        {
+            return new StreamedScalarValueInfo(typeof(object));
+        }
+
+        public override void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+            //no parameters so just ignore this
+            //throw new NotImplementedException();
+        }
+
+        public override string ToString()
+        {
+            return "Explain()";
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Operators/LinqQueryRequestDataInfo.cs
+++ b/src/Couchbase.EntityFramework/Operators/LinqQueryRequestDataInfo.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Couchbase.EntityFramework.QueryGeneration;
+using Remotion.Linq;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.EntityFramework.Operators
+{
+    /// <summary>
+    /// Implementation of <see cref="IStreamedDataInfo"/> for a query where <see cref="ToQueryRequestResultOperator"/>
+    /// was applied.
+    /// </summary>
+    internal class LinqQueryRequestDataInfo : IStreamedDataInfo
+    {
+        private readonly bool _returnDefaultWhenEmpty;
+
+        public Type DataType
+        {
+            get { return typeof(LinqQueryRequest); }
+        }
+
+        /// <summary>
+        /// For queries returning a single result, true indicates that an empty result set should return the default value.
+        /// For example, a call to .FirstOrDefault() would set this to true.
+        /// </summary>
+        public bool ReturnDefaultWhenEmpty
+        {
+            get { return _returnDefaultWhenEmpty; }
+        }
+
+        public LinqQueryRequestDataInfo(bool returnDefaultWhenEmpty)
+        {
+            _returnDefaultWhenEmpty = returnDefaultWhenEmpty;
+        }
+
+        public IStreamedData ExecuteQueryModel(QueryModel queryModel, IQueryExecutor executor)
+        {
+            if (queryModel == null)
+            {
+                throw new ArgumentNullException("queryModel");
+            }
+            if (executor == null)
+            {
+                throw new ArgumentNullException("executor");
+            }
+
+            var result = executor.ExecuteSingle<LinqQueryRequest>(queryModel, false);
+
+            // Pass the value of ReturnDefaultWhenEmpty into the resulting LinqQueryRequest
+            result.ReturnDefaultWhenEmpty = ReturnDefaultWhenEmpty;
+
+            return new LinqQueryRequestValue(result, this);
+        }
+
+        public IStreamedDataInfo AdjustDataType(Type dataType)
+        {
+            if (dataType == null)
+            {
+                throw new ArgumentNullException("dataType");
+            }
+
+            if (dataType != typeof(LinqQueryRequest))
+            {
+                throw new ArgumentException("Invalid dataType for LinqQueryRequestDataInfo.", "dataType");
+            }
+
+            return new LinqQueryRequestDataInfo(ReturnDefaultWhenEmpty);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as IStreamedDataInfo);
+        }
+
+        public virtual bool Equals(IStreamedDataInfo obj)
+        {
+            var objAsLinqQueryRequestDataInfo = obj as LinqQueryRequestDataInfo;
+            if (objAsLinqQueryRequestDataInfo == null)
+            {
+                return false;
+            }
+
+            return ReturnDefaultWhenEmpty == objAsLinqQueryRequestDataInfo.ReturnDefaultWhenEmpty;
+        }
+
+        public override int GetHashCode()
+        {
+            return ReturnDefaultWhenEmpty.GetHashCode();
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Operators/LinqQueryRequestValue.cs
+++ b/src/Couchbase.EntityFramework/Operators/LinqQueryRequestValue.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Couchbase.EntityFramework.QueryGeneration;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.EntityFramework.Operators
+{
+    /// <summary>
+    /// Implementation of <see cref="IStreamedData"/> for a query where <see cref="ToQueryRequestResultOperator"/>
+    /// was applied.  Value will be a <see cref="LinqQueryRequest"/>.
+    /// </summary>
+    internal class LinqQueryRequestValue : IStreamedData
+    {
+        public IStreamedDataInfo DataInfo { get; private set; }
+
+        public object Value { get; private set; }
+
+        public LinqQueryRequestValue(LinqQueryRequest value, LinqQueryRequestDataInfo linqQueryRequestInfo)
+        {
+            if (linqQueryRequestInfo == null)
+            {
+                throw new ArgumentNullException("linqQueryRequestInfo");
+            }
+
+            Value = value;
+            DataInfo = linqQueryRequestInfo;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Operators/ToQueryRequestExpressionNode.cs
+++ b/src/Couchbase.EntityFramework/Operators/ToQueryRequestExpressionNode.cs
@@ -1,0 +1,40 @@
+﻿using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.QueryGeneration;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Couchbase.EntityFramework.Operators
+{
+    /// <summary>
+    /// Expression parser for LinqQueryRequest.ToQueryRequest method.
+    /// </summary>
+    internal class ToQueryRequestExpressionNode : ResultOperatorExpressionNodeBase
+    {
+        public static readonly MethodInfo[] SupportedMethods =
+        {
+            typeof (LinqQueryRequest).GetMethod("ToQueryRequest", BindingFlags.NonPublic | BindingFlags.Static)
+        };
+
+        public ToQueryRequestExpressionNode(MethodCallExpressionParseInfo parseInfo)
+            : base(parseInfo, null, null)
+        {
+        }
+
+        protected override ResultOperatorBase CreateResultOperator(
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return new ToQueryRequestResultOperator();
+        }
+
+        public override Expression Resolve(ParameterExpression inputParameter,
+            Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            return Source.Resolve(
+                inputParameter,
+                expressionToBeResolved,
+                clauseGenerationContext);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Operators/ToQueryRequestResultOperator.cs
+++ b/src/Couchbase.EntityFramework/Operators/ToQueryRequestResultOperator.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Linq.Expressions;
+using Couchbase.EntityFramework.QueryGeneration;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.ResultOperators;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Couchbase.EntityFramework.Operators
+{
+    /// <summary>
+    /// When present on a query model, indicates that the raw query string should be returned in a
+    /// <see cref="LinqQueryRequest"/>.
+    /// </summary>
+    internal class ToQueryRequestResultOperator : ValueFromSequenceResultOperatorBase
+    {
+        public override StreamedValue ExecuteInMemory<T>(StreamedSequence input)
+        {
+            throw new NotImplementedException("Cannot create N1QL query requests in memory");
+        }
+
+        public override ResultOperatorBase Clone(CloneContext cloneContext)
+        {
+            return new ToQueryRequestResultOperator();
+        }
+
+        public override IStreamedDataInfo GetOutputDataInfo(IStreamedDataInfo inputInfo)
+        {
+            var returnDefaultWhenEmpty = false;
+
+            var inputAsStreamedSingle = inputInfo as StreamedSingleValueInfo;
+            if (inputAsStreamedSingle != null)
+            {
+                // If the incoming stream is a StreamedSingleValueInfo (i.e. .First() or .Single()),
+                // retain the ReturnDefaultWhenEmpty property.  This will cause it to be applied to
+                // the created LinqQueryRequest.
+
+                returnDefaultWhenEmpty = inputAsStreamedSingle.ReturnDefaultWhenEmpty;
+            }
+
+            return new LinqQueryRequestDataInfo(returnDefaultWhenEmpty);
+        }
+
+        public override void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+            //no parameters so just ignore this
+        }
+
+        public override string ToString()
+        {
+            return "ToQueryRequest()";
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Proxies/DocumentCollection.cs
+++ b/src/Couchbase.EntityFramework/Proxies/DocumentCollection.cs
@@ -1,0 +1,114 @@
+﻿using System.Collections.ObjectModel;
+using Couchbase.EntityFramework.Metadata;
+
+namespace Couchbase.EntityFramework.Proxies
+{
+    /// <summary>
+    /// Represents a collection that is also an <see cref="ITrackedDocumentNode"/> node.  It keeps a dirty status, and monitors
+    /// all child nodes which also implement ITrackedDocumentNode for modifications.
+    /// </summary>
+    /// <typeparam name="T">Type of object in the collection</typeparam>
+    class DocumentCollection<T> : Collection<T>, ITrackedDocumentNode
+    {
+        private readonly DocumentNode _documentNode = new DocumentNode();
+
+        #region ITrackedDocumentNode
+
+        // Redirect all ITrackedDocumentNode calls to the DocumentNode
+
+        public bool IsDeleted { get; set; }
+
+        public bool IsDeserializing
+        {
+            get { return _documentNode.IsDeserializing; }
+            set { _documentNode.IsDeserializing = value; }
+        }
+
+        public bool IsDirty
+        {
+            get { return _documentNode.IsDirty; }
+            set { _documentNode.IsDirty = value; }
+        }
+
+        public DocumentMetadata Metadata
+        {
+            get { return _documentNode.Metadata; }
+            set { _documentNode.Metadata = value; }
+        }
+
+        public void RegisterChangeTracking(ITrackedDocumentNodeCallback callback)
+        {
+            _documentNode.RegisterChangeTracking(callback);
+        }
+
+        public void UnregisterChangeTracking(ITrackedDocumentNodeCallback callback)
+        {
+            _documentNode.UnregisterChangeTracking(callback);
+        }
+
+        public void ClearStatus()
+        {
+            _documentNode.ClearStatus();
+        }
+
+        #endregion
+
+        protected override void ClearItems()
+        {
+            if (Count > 0)
+            {
+                base.ClearItems();
+
+                _documentNode.RemoveAllChildren();
+                _documentNode.DocumentModified(this);
+            }
+        }
+
+        protected override void InsertItem(int index, T item)
+        {
+            base.InsertItem(index, item);
+
+            var status = item as ITrackedDocumentNode;
+            if (status != null)
+            {
+                _documentNode.AddChild(status);
+            }
+
+            _documentNode.DocumentModified(this);
+        }
+
+        protected override void RemoveItem(int index)
+        {
+            var status = this[index] as ITrackedDocumentNode;
+            if (status != null)
+            {
+                _documentNode.RemoveChild(status);
+            }
+
+            base.RemoveItem(index);
+
+            _documentNode.DocumentModified(this);
+        }
+
+        protected override void SetItem(int index, T item)
+        {
+            var status = this[index] as ITrackedDocumentNode;
+            if (status != null)
+            {
+                // Remove the old value from the child collection
+                _documentNode.RemoveChild(status);
+            }
+
+            base.SetItem(index, item);
+
+            status = item as ITrackedDocumentNode;
+            if (status != null)
+            {
+                // Add the new value to the child collection
+                _documentNode.AddChild(status);
+            }
+
+            _documentNode.DocumentModified(this);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Proxies/DocumentNode.cs
+++ b/src/Couchbase.EntityFramework/Proxies/DocumentNode.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Couchbase.EntityFramework.Metadata;
+
+namespace Couchbase.EntityFramework.Proxies
+{
+    /// <summary>
+    /// Represents the status of a node in a document.  Also keeps a collection of child nodes which are monitored for changes.
+    /// </summary>
+    internal class DocumentNode : ITrackedDocumentNode, ITrackedDocumentNodeCallback
+    {
+        public DocumentNode()
+        {
+            Metadata = new DocumentMetadata();
+        }
+
+        public bool IsDeleted { get; set; }
+
+        public bool IsDeserializing { get; set; }
+
+        public bool IsDirty { get; set; }
+
+        public DocumentMetadata Metadata { get; set; }
+
+        #region Child Document Tracking
+
+        /// <summary>
+        /// Keep a list of all child documents so that we can recurse down through the tree.
+        /// Value of the dictionary is a reference count, in case the same document is beneath two properties.
+        /// </summary>
+        private readonly Dictionary<ITrackedDocumentNode, int> _childDocuments =
+            new Dictionary<ITrackedDocumentNode, int>();
+
+        public void AddChild(ITrackedDocumentNode child)
+        {
+            lock (_childDocuments)
+            {
+                if (_childDocuments.ContainsKey(child))
+                {
+                    _childDocuments[child] += 1;
+                }
+                else
+                {
+                    _childDocuments.Add(child, 1);
+
+                    child.RegisterChangeTracking(this);
+                }
+            }
+        }
+
+        public void RemoveChild(ITrackedDocumentNode child)
+        {
+            lock (_childDocuments)
+            {
+                int refCount;
+                if (_childDocuments.TryGetValue(child, out refCount))
+                {
+                    refCount -= 1;
+
+                    if (refCount > 0)
+                    {
+                        _childDocuments[child] = refCount;
+                    }
+                    else
+                    {
+                        _childDocuments.Remove(child);
+
+                        child.UnregisterChangeTracking(this);
+                    }
+                }
+            }
+        }
+
+        public void RemoveAllChildren()
+        {
+            lock (_childDocuments)
+            {
+                foreach (var child in _childDocuments)
+                {
+                    child.Key.UnregisterChangeTracking(this);
+                }
+
+                _childDocuments.Clear();
+            }
+        }
+
+        #endregion
+
+        #region Change Tracking Callbacks
+
+        /// <summary>
+        /// List of callbacks to bubble dirty status back up the tree
+        /// </summary>
+        private readonly List<WeakReference<ITrackedDocumentNodeCallback>> _callbacks =
+            new List<WeakReference<ITrackedDocumentNodeCallback>>();
+
+        /// <summary>
+        /// Register a callback to be triggered when this document is modified
+        /// </summary>
+        /// <param name="callback">Callback to be triggered</param>
+        public virtual void RegisterChangeTracking(ITrackedDocumentNodeCallback callback)
+        {
+            lock (_callbacks)
+            {
+                var isAlreadyTracked = _callbacks.Any(p =>
+                {
+                    ITrackedDocumentNodeCallback target;
+
+                    if (p.TryGetTarget(out target))
+                    {
+                        return target == callback;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                });
+
+                if (!isAlreadyTracked)
+                {
+                    _callbacks.Add(new WeakReference<ITrackedDocumentNodeCallback>(callback));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Unregister a callback so it will no longer be called when this document is modified
+        /// </summary>
+        /// <param name="callback">Callback to unregister</param>
+        public virtual void UnregisterChangeTracking(ITrackedDocumentNodeCallback callback)
+        {
+            lock (_callbacks)
+            {
+                _callbacks.RemoveAll(p =>
+                {
+                    ITrackedDocumentNodeCallback target;
+
+                    if (p.TryGetTarget(out target))
+                    {
+                        return target == callback;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                });
+            }
+        }
+
+        /// <summary>
+        /// Trigger any callbacks to inform them that this document has been modified
+        /// </summary>
+        private void TriggerCallbacks()
+        {
+            lock (_callbacks)
+            {
+                foreach (var callback in _callbacks)
+                {
+                    ITrackedDocumentNodeCallback target;
+
+                    if (callback.TryGetTarget(out target))
+                    {
+                        target.DocumentModified(this);
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Clears IsDeserializing and IsDirty on this document and all child documents.
+        /// Does nothing if IsDeserialization is already false to prevent accidental infinite recursion.
+        /// </summary>
+        public virtual void ClearStatus()
+        {
+            if (IsDeserializing || IsDirty)
+            {
+                lock (_childDocuments)
+                {
+                    // Clear flags first to prevent accidental infinite recursion
+                    IsDirty = false;
+                    IsDeserializing = false;
+
+                    foreach (var childDocument in _childDocuments.Select(p => p.Key))
+                    {
+                        childDocument.ClearStatus();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Flag this node as modified, and trigger any registered <see cref="ITrackedDocumentNodeCallback" /> callbacks.
+        /// </summary>
+        public virtual void DocumentModified(ITrackedDocumentNode mutatedDocument)
+        {
+            if (!IsDirty && !IsDeserializing)
+            {
+                // Don't trigger callbacks if already marked as dirty before
+                // And don't mark as dirty or trigger callbacks if still deserializing
+
+                // Set as dirty before triggering callbacks to prevent accidental infinite recursion
+                IsDirty = true;
+
+                //Context.Track(this);
+
+                TriggerCallbacks();
+            }
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Proxies/DocumentProxyBuilder.cs
+++ b/src/Couchbase.EntityFramework/Proxies/DocumentProxyBuilder.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Castle.Core.Logging;
+using Castle.DynamicProxy;
+using Castle.DynamicProxy.Generators;
+
+namespace Couchbase.EntityFramework.Proxies
+{
+    /// <summary>
+    /// Overrides <see cref="CreateClassProxyType"/> for an existing <see cref="IProxyBuilder"/> so that it uses
+    /// <see cref="DocumentProxyGenerator"/> instead of the default <see cref="ClassProxyGenerator"/>.
+    /// </summary>
+    class DocumentProxyBuilder : IProxyBuilder
+    {
+        private readonly IProxyBuilder _baseProxyBuilder;
+
+        public ILogger Logger
+        {
+            get { return _baseProxyBuilder.Logger; }
+            set { _baseProxyBuilder.Logger = value; }
+        }
+
+        public ModuleScope ModuleScope
+        {
+            get { return _baseProxyBuilder.ModuleScope; }
+        }
+
+        /// <summary>
+        /// Creates a DocumentProxyBuilder instance.
+        /// </summary>
+        public DocumentProxyBuilder() : this(new DefaultProxyBuilder())
+        {
+        }
+
+        /// <summary>
+        /// Creates a DocumentProxyBuilder instance.
+        /// </summary>
+        /// <param name="scope"><see cref="ModuleScope"/> to use for <see cref="DefaultProxyBuilder"/>.</param>
+        public DocumentProxyBuilder(ModuleScope scope) : this(new DefaultProxyBuilder(scope))
+        {
+        }
+
+        /// <summary>
+        /// Creates a DocumentProxyBuilder instance.
+        /// </summary>
+        /// <param name="baseProxyBuilder">Base <see cref="IProxyBuilder"/> to use for all calls other than <see cref="CreateClassProxyType"/>.</param>
+        public DocumentProxyBuilder(IProxyBuilder baseProxyBuilder)
+        {
+            if (baseProxyBuilder == null)
+            {
+                throw new ArgumentNullException("baseProxyBuilder");
+            }
+
+            _baseProxyBuilder = baseProxyBuilder;
+        }
+
+        public Type CreateClassProxyType(Type classToProxy, Type[] additionalInterfacesToProxy, ProxyGenerationOptions options)
+        {
+            var generator = new DocumentProxyGenerator(ModuleScope, classToProxy)
+            {
+                Logger = Logger
+            };
+
+            return generator.GenerateCode(additionalInterfacesToProxy, options);
+        }
+
+        public Type CreateClassProxyTypeWithTarget(Type classToProxy, Type[] additionalInterfacesToProxy,
+            ProxyGenerationOptions options)
+        {
+            return _baseProxyBuilder.CreateClassProxyTypeWithTarget(classToProxy, additionalInterfacesToProxy, options);
+        }
+
+        public Type CreateInterfaceProxyTypeWithTarget(Type interfaceToProxy, Type[] additionalInterfacesToProxy, Type targetType,
+            ProxyGenerationOptions options)
+        {
+            return _baseProxyBuilder.CreateInterfaceProxyTypeWithTarget(interfaceToProxy, additionalInterfacesToProxy, targetType, options);
+        }
+
+        public Type CreateInterfaceProxyTypeWithTargetInterface(Type interfaceToProxy, Type[] additionalInterfacesToProxy,
+            ProxyGenerationOptions options)
+        {
+            return _baseProxyBuilder.CreateInterfaceProxyTypeWithTargetInterface(interfaceToProxy, additionalInterfacesToProxy, options);
+        }
+
+        public Type CreateInterfaceProxyTypeWithoutTarget(Type interfaceToProxy, Type[] additionalInterfacesToProxy,
+            ProxyGenerationOptions options)
+        {
+            return _baseProxyBuilder.CreateInterfaceProxyTypeWithoutTarget(interfaceToProxy, additionalInterfacesToProxy, options);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Proxies/DocumentProxyDataMapper.cs
+++ b/src/Couchbase.EntityFramework/Proxies/DocumentProxyDataMapper.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Couchbase.Configuration.Client;
+using Couchbase.Core.Serialization;
+using Couchbase.Linq;
+using Couchbase.Views;
+
+namespace Couchbase.EntityFramework.Proxies
+{
+    /// <summary>
+    /// Alternate IDataMapper to use for reading N1QL queries which generates document proxies that implement change tracking.
+    /// Requires that <see cref="ClientConfiguration.Serializer"/> be an instance of <see cref="IExtendedTypeSerializer"/>.  The serializer
+    /// must also support <see cref="SupportedDeserializationOptions.CustomObjectCreator"/>.
+    /// </summary>
+    /// <typeparam name="TRow">Type of data row being proxied</typeparam>
+    internal class DocumentProxyDataMapper<TRow> : IDataMapper
+    {
+        private readonly IExtendedTypeSerializer _serializer;
+        private readonly IChangeTrackableContext _context;
+
+        public DocumentProxyDataMapper(ITypeSerializer serializer, IChangeTrackableContext context)
+        {
+            _serializer = (serializer ?? throw new ArgumentNullException(nameof(serializer))) as IExtendedTypeSerializer;
+
+            if (_serializer == null || !_serializer.SupportedDeserializationOptions.CustomObjectCreator)
+            {
+                throw new NotSupportedException("Change tracking is not supported without an IExtendedTypeSerializer which supports CustomObjectCreator.");
+            }
+
+            _context = context;
+
+            _serializer.DeserializationOptions = new DeserializationOptions
+            {
+                CustomObjectCreator = new DocumentProxyTypeCreator()
+            };
+        }
+
+        /// <summary>
+        /// Maps a single row.
+        /// </summary>
+        /// <typeparam name="T">The type of document to deserialize.</typeparam>
+        /// <param name="stream">The <see cref="Stream"/> results of the query.</param>
+        /// <returns>An object deserialized to it's T type.</returns>
+        public T Map<T>(Stream stream) where T : class
+        {
+            var queryResults = _serializer.Deserialize<T>(stream);
+
+            // The use of reflection here isn't terribly efficient.  However, for a N1QL query this method will
+            // only be called once for a single IQueryResult<T>, so the performance penalty is very negligible.
+
+            // Find a property returning IEnumerable<T>, this will be the rows of the result
+            var property = queryResults.GetType().GetProperties()
+                .FirstOrDefault(p => typeof(IEnumerable<TRow>).IsAssignableFrom(p.PropertyType));
+            if (property != null)
+            {
+                // Map was called for an IQueryResult<T> object, so go through all of the rows and call
+                // ITrackedDocumentNode.ClearStatus to indicate that deserialization is complete.
+
+                ClearStatusOnQueryRequestRows(
+                    (IEnumerable<TRow>) property.GetMethod.Invoke(queryResults, null),
+                    _context);
+            }
+
+            return queryResults;
+        }
+
+        public static void ClearStatusOnQueryRequestRows(IEnumerable<TRow> rows, IChangeTrackableContext context)
+        {
+            if (rows != null)
+            {
+                foreach (var row in rows)
+                {
+                    var status = row as ITrackedDocumentNode;
+                    if (status != null)
+                    {
+                        // Track the document
+                        context.Track(row);
+
+                        // Clear the deserialization flags to start change tracking
+                        status.ClearStatus();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Proxies/DocumentProxyGenerationHook.cs
+++ b/src/Couchbase.EntityFramework/Proxies/DocumentProxyGenerationHook.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Reflection;
+using Castle.DynamicProxy;
+
+namespace Couchbase.EntityFramework.Proxies
+{
+    /// <summary>
+    /// Hook to control generation of proxies for document objects
+    /// </summary>
+    class DocumentProxyGenerationHook : IProxyGenerationHook
+    {
+        public override bool Equals(object obj)
+        {
+            // Always treat DocumentProxyGenerationHook objects as equal
+            // So that the generated proxy type is cached and reused
+
+            return obj is DocumentProxyGenerationHook;
+        }
+
+        public override int GetHashCode()
+        {
+            // Always treat DocumentProxyGenerationHook objects as equal
+            // So that the generated proxy type is cached and reused
+
+            return 0;
+        }
+
+        public void MethodsInspected()
+        {
+        }
+
+        public void NonProxyableMemberNotification(Type type, MemberInfo memberInfo)
+        {
+            // TODO Logging of non-virtual property setters for debugging purposes
+        }
+
+        public bool ShouldInterceptMethod(Type type, MethodInfo methodInfo)
+        {
+            if (type == typeof (ITrackedDocumentNode))
+            {
+                // All calls for ITrackedDocumentNode should go to the interceptor
+
+                return true;
+            }
+
+            // Only proxy getters and setters for properties on the document
+            // We must proxy getters or serializing the document back to Couchbase has problems
+
+            return methodInfo.IsSpecialName && (methodInfo.Name.StartsWith("set_") || methodInfo.Name.StartsWith("get_"));
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Proxies/DocumentProxyGenerator.cs
+++ b/src/Couchbase.EntityFramework/Proxies/DocumentProxyGenerator.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.Serialization;
+using Castle.DynamicProxy;
+using Castle.DynamicProxy.Generators;
+using Castle.DynamicProxy.Generators.Emitters;
+using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
+using Couchbase.EntityFramework.Metadata;
+
+namespace Couchbase.EntityFramework.Proxies
+{
+    /// <summary>
+    /// Inherited from <see cref="DocumentProxyGenerator"/>, this generator applies <see cref="IgnoreDataMemberAttribute"/>
+    /// to the emitted "__interceptors" field.  This prevents it from  being serialized by JSON serializers.
+    /// </summary>
+    internal class DocumentProxyGenerator : ClassProxyGenerator
+    {
+        private const string InterceptorsFieldName = "__interceptors";
+
+        private static readonly MethodInfo SetMetadata =
+            typeof (DocumentProxyInterceptor).GetMethod("SetMetadata");
+
+        public DocumentProxyGenerator(ModuleScope scope, Type targetType) : base(scope, targetType)
+        {
+        }
+
+        protected override void CreateFields(ClassEmitter emitter)
+        {
+            base.CreateFields(emitter);
+
+            var interceptorsField = emitter.GetField(InterceptorsFieldName);
+            if (interceptorsField != null)
+            {
+                emitter.DefineCustomAttributeFor<IgnoreDataMemberAttribute>(interceptorsField);
+
+                CreateMetadataProperty(emitter, interceptorsField);
+            }
+        }
+
+        /// <summary>
+        /// Creates an intercepted property named __metadata, which only has a setter, which is used to deserialize
+        /// the document metadata.  Since there is no getter, it won't be serialized back to the data store.
+        /// </summary>
+        private void CreateMetadataProperty(ClassEmitter emitter, FieldReference interceptorsField)
+        {
+            var propertyBuilder = emitter.TypeBuilder.DefineProperty("__metadata", PropertyAttributes.None, CallingConventions.HasThis,
+                typeof (DocumentMetadata), null, null, null, null, null);
+
+            var methodBuilder = emitter.TypeBuilder.DefineMethod("set___metadata", MethodAttributes.Public | MethodAttributes.SpecialName);
+            methodBuilder.SetParameters(typeof (DocumentMetadata));
+
+            var codeBuilder = methodBuilder.GetILGenerator();
+            codeBuilder.Emit(OpCodes.Ldarg_0);
+            codeBuilder.Emit(OpCodes.Ldfld, interceptorsField.Fieldbuilder);
+            codeBuilder.Emit(OpCodes.Ldc_I4_0);
+            codeBuilder.Emit(OpCodes.Ldelem, typeof(IInterceptor));
+            codeBuilder.Emit(OpCodes.Castclass, typeof(DocumentProxyInterceptor));
+            codeBuilder.Emit(OpCodes.Ldarg_1);
+            codeBuilder.Emit(OpCodes.Call, SetMetadata);
+            codeBuilder.Emit(OpCodes.Ret);
+
+            propertyBuilder.SetSetMethod(methodBuilder);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Proxies/DocumentProxyInterceptor.cs
+++ b/src/Couchbase.EntityFramework/Proxies/DocumentProxyInterceptor.cs
@@ -1,0 +1,81 @@
+﻿using System.Linq;
+using Castle.DynamicProxy;
+using Couchbase.EntityFramework.Metadata;
+
+namespace Couchbase.EntityFramework.Proxies
+{
+    internal class DocumentProxyInterceptor : IInterceptor
+    {
+        private readonly DocumentNode _documentNode = new DocumentNode();
+
+        /// <summary>
+        /// Used by intercepted __metadata property generated on the proxy.  We use this special
+        /// setter so that it isn't serialized back to the data store.
+        /// </summary>
+        /// <param name="metadata"></param>
+        public void SetMetadata(DocumentMetadata metadata)
+        {
+            _documentNode.Metadata = metadata;
+        }
+
+        public void Intercept(IInvocation invocation)
+        {
+            if (invocation.InvocationTarget == null)
+            {
+                // This is a call against an ITrackedDocumentNode member
+                // So redirect to the members on the DocumentNode
+
+                invocation.ReturnValue = invocation.Method.Invoke(_documentNode, invocation.Arguments);
+                return;
+            }
+
+            // ReSharper disable once PossibleNullReferenceException
+            var property = invocation.Method.DeclaringType.GetProperties()
+                .FirstOrDefault(prop => prop.CanWrite && prop.GetSetMethod().Equals(invocation.Method));
+
+            if (property == null)
+            {
+                // Not a property setter, don't intercept
+                invocation.Proceed();
+                return;
+            }
+
+            var getMethod = property.GetGetMethod();
+
+            if (getMethod == null)
+            {
+                // Not a property with a getter and setter, don't intercept
+                invocation.Proceed();
+                return;
+            }
+
+            // Save the previous value
+            object initialValue = getMethod.Invoke(invocation.InvocationTarget, null);
+
+            invocation.Proceed();
+
+            // Get the new value
+            object finalValue = getMethod.Invoke(invocation.InvocationTarget, null);
+
+            if ((initialValue == null) && (finalValue != null) ||
+                (initialValue != null && !initialValue.Equals(finalValue)))
+            {
+                // Value was changed
+
+                var status = initialValue as ITrackedDocumentNode;
+                if (status != null)
+                {
+                    _documentNode.RemoveChild(status);
+                }
+
+                status = finalValue as ITrackedDocumentNode;
+                if (status != null)
+                {
+                    _documentNode.AddChild(status);
+                }
+
+                _documentNode.DocumentModified(status);
+            }
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Proxies/DocumentProxyManager.cs
+++ b/src/Couchbase.EntityFramework/Proxies/DocumentProxyManager.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Castle.DynamicProxy;
+
+namespace Couchbase.EntityFramework.Proxies
+{
+    /// <summary>
+    /// Manages the creation of proxies for document nodes.  These proxies implement <see cref="ITrackedDocumentNode"/> for change tracking.
+    /// Proxies will track changes on any property implemented as virtual.  Any such property which is assigned an
+    /// object which also implements <see cref="ITrackedDocumentNode"/> will have changes tracked if the child
+    /// node changes.
+    /// </summary>
+    /// <remarks>
+    /// For performance reasons, should be used as a singleton.  This then makes <see cref="Castle.DynamicProxy.ProxyGenerator"/> a singleton as well,
+    /// which means it will cache and reuse the proxy types.  The <see cref="DocumentProxyManager.Default"/> property
+    /// provides a singleton instance with a default <see cref="Castle.DynamicProxy.ProxyGenerator"/> for normal use.
+    /// </remarks>
+    internal class DocumentProxyManager
+    {
+        private static readonly Type[] InterfacesToProxy = {typeof (ITrackedDocumentNode)};
+
+        private static readonly ProxyGenerationOptions Options = new ProxyGenerationOptions()
+        {
+            Hook = new DocumentProxyGenerationHook()
+        };
+
+        /// <summary>
+        /// Singleton instance of <see cref="DocumentProxyManager"/> for use creating document proxies.
+        /// </summary>
+        public static DocumentProxyManager Default { get; set; }
+
+        private readonly ProxyGenerator _proxyGenerator;
+        /// <summary>
+        /// <see cref="Castle.DynamicProxy.ProxyGenerator"/> used to create proxies.
+        /// </summary>
+        public ProxyGenerator ProxyGenerator
+        {
+            get { return _proxyGenerator; }
+        }
+
+        /// <summary>
+        /// Static constructor
+        /// </summary>
+        static DocumentProxyManager()
+        {
+            Default = new DocumentProxyManager();
+        }
+
+        /// <summary>
+        /// Creates a new DocumentProxyManager with a default <see cref="Castle.DynamicProxy.ProxyGenerator"/>.
+        /// </summary>
+        public DocumentProxyManager() : this(new ProxyGenerator(new DocumentProxyBuilder()))
+        {
+        }
+
+        /// <summary>
+        /// Creates a new DocumentProxyManager with a given <see cref="Castle.DynamicProxy.ProxyGenerator"/>.
+        /// </summary>
+        /// <param name="proxyGenerator"><see cref="Castle.DynamicProxy.ProxyGenerator"/> used to create proxies.</param>
+        public DocumentProxyManager(ProxyGenerator proxyGenerator)
+        {
+            if (proxyGenerator == null)
+            {
+                throw new ArgumentNullException("proxyGenerator");
+            }
+
+            _proxyGenerator = proxyGenerator;
+        }
+
+        /// <summary>
+        /// Create a proxy of a document that implements <see cref="ITrackedDocumentNode"/> for change tracking.
+        /// Proxy will track changes on any property implemented as virtual.  Any such property which is assigned an
+        /// object which also implements <see cref="ITrackedDocumentNode"/> will have changes tracked if the child
+        /// node changes.
+        /// </summary>
+        /// <param name="documentType">Type of document to proxy.</param>
+        /// <returns>New instance of a proxy implementing <see cref="ITrackedDocumentNode"/>.</returns>
+        public virtual object CreateProxy(Type documentType)
+        {
+            return ProxyGenerator.CreateClassProxy(documentType, InterfacesToProxy, Options,
+                    new DocumentProxyInterceptor());
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Proxies/DocumentProxyTypeCreator.cs
+++ b/src/Couchbase.EntityFramework/Proxies/DocumentProxyTypeCreator.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Couchbase.Core.Serialization;
+using Couchbase.Linq;
+
+namespace Couchbase.EntityFramework.Proxies
+{
+    /// <summary>
+    /// Implements an <see cref="ICustomObjectCreator"/> which creates proxies that implement <see cref="ITrackedDocumentNode"/>.
+    /// </summary>
+    internal class DocumentProxyTypeCreator : ICustomObjectCreator
+    {
+        private static readonly Assembly Mscorlib = typeof(string).GetTypeInfo().Assembly;
+        private static readonly Assembly Couchbase = typeof(Couchbase.Core.IBucket).GetTypeInfo().Assembly;
+
+        public bool CanCreateObject(Type type)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException("type");
+            }
+
+            Type collectionType;
+            if (IsProxyableCollection(type, out collectionType))
+            {
+                // Proxy collection interfaces
+                return true;
+            }
+
+            if (!type.GetTypeInfo().IsClass || type.GetTypeInfo().IsSealed || typeof(Delegate).IsAssignableFrom(type))
+            {
+                return false;
+            }
+
+            var interfaces = type.GetInterfaces();
+            if (interfaces.Any(p => p.GetTypeInfo().UnderlyingSystemType == typeof (IBucketContext)))
+            {
+                //don't proxy the context
+                return false;
+            }
+
+            // Don't proxy classes from mscorlib or Couchbase SDK, but proxy everything else
+            return !type.GetTypeInfo().Assembly.Equals(Mscorlib) && !type.GetTypeInfo().Assembly.Equals(Couchbase);
+        }
+
+        public object CreateObject(Type type)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException("type");
+            }
+
+            // For performance, don't repeat the CanCreateObject tests
+            // We must assume that CanCreateObject was verified before this method was called
+
+            object document;
+            Type collectionType;
+
+            if (IsProxyableCollection(type, out collectionType))
+            {
+                document = Activator.CreateInstance(collectionType);
+            }
+            else
+            {
+                document = DocumentProxyManager.Default.CreateProxy(type);
+            }
+
+            ((ITrackedDocumentNode)document).IsDeserializing = true;
+
+            return document;
+        }
+
+        #region Collection Helpers
+
+        /// <summary>
+        /// Caches collection types for reuse to prevent excess reflection.
+        /// Key is the document type, value is the resulting collection type.
+        /// Null value indicates that the document type is not a proxyable collection.
+        /// </summary>
+        private readonly Dictionary<Type, Type> _collectionTypeCache = new Dictionary<Type, Type>();
+
+        private bool IsProxyableCollection(Type documentType, out Type collectionType)
+        {
+            if (_collectionTypeCache.TryGetValue(documentType, out collectionType))
+            {
+                return collectionType != null;
+            }
+
+            Type elementType = null;
+
+            // Check to see if the documentType is ICollection<T> or IList<T>, and extract the element type
+
+            if (documentType.GetTypeInfo().IsInterface && documentType.GetTypeInfo().IsGenericType)
+            {
+                Type genericDefinition = documentType.GetGenericTypeDefinition();
+
+                if ((genericDefinition == typeof(ICollection<>)) || (genericDefinition == typeof(IList<>)))
+                {
+                    elementType = documentType.GenericTypeArguments[0];
+                }
+            }
+
+            if (elementType != null)
+            {
+                // This is a valid collection type, so build the resulting collectionType
+                // And store in the cache for reuse
+
+                collectionType = typeof (DocumentCollection<>).MakeGenericType(elementType);
+
+                _collectionTypeCache.Add(documentType, collectionType);
+
+                return true;
+            }
+            else
+            {
+                // This is not a valid collection type.  Store this fact in the cache for reuse.
+
+                _collectionTypeCache.Add(documentType, null);
+
+                return false;
+            }
+        }
+
+        #endregion
+
+    }
+}

--- a/src/Couchbase.EntityFramework/Proxies/ITrackedDocumentNode.cs
+++ b/src/Couchbase.EntityFramework/Proxies/ITrackedDocumentNode.cs
@@ -1,0 +1,33 @@
+﻿using System.Runtime.Serialization;
+using Couchbase.EntityFramework.Metadata;
+
+namespace Couchbase.EntityFramework.Proxies
+{
+    internal interface ITrackedDocumentNode
+    {
+        [IgnoreDataMember]
+        bool IsDeleted { get; set; }
+
+        [IgnoreDataMember]
+        bool IsDeserializing { get; set; }
+
+        [IgnoreDataMember]
+        bool IsDirty { get; set; }
+
+        /// <summary>
+        /// If this is the root node in a document tree, this should contain the document metadata.  Otherwise null.
+        /// </summary>
+        [IgnoreDataMember]
+        DocumentMetadata Metadata { get; set; }
+
+        void RegisterChangeTracking(ITrackedDocumentNodeCallback callback);
+
+        void UnregisterChangeTracking(ITrackedDocumentNodeCallback callback);
+
+        /// <summary>
+        /// Clears IsDeserializing and IsDirty on this document and all child documents.
+        /// Does nothing if IsDeserialization is already false to prevent accidental infinite recursion.
+        /// </summary>
+        void ClearStatus();
+    }
+}

--- a/src/Couchbase.EntityFramework/Proxies/ITrackedDocumentNodeCallback.cs
+++ b/src/Couchbase.EntityFramework/Proxies/ITrackedDocumentNodeCallback.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Couchbase.EntityFramework.Proxies
+{
+    internal interface ITrackedDocumentNodeCallback
+    {
+        void DocumentModified(ITrackedDocumentNode mutatedDocument);
+    }
+}

--- a/src/Couchbase.EntityFramework/Proxies/NewDocumentWrapper.cs
+++ b/src/Couchbase.EntityFramework/Proxies/NewDocumentWrapper.cs
@@ -1,0 +1,7 @@
+﻿namespace Couchbase.EntityFramework.Proxies
+{
+    internal class NewDocumentWrapper : DocumentNode
+    {
+        public object Value { get; set; }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/DefaultMethodCallTranslatorProvider.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/DefaultMethodCallTranslatorProvider.cs
@@ -1,0 +1,277 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators;
+
+namespace Couchbase.EntityFramework.QueryGeneration
+{
+
+    /// <summary>
+    /// Provides default method call translator provider for N1QL expressions.
+    /// Uses classes implementing <see cref="IMethodCallTranslator" /> defined in Couchbase.Linq assembly,
+    /// as well as any method which implements <see cref="N1QlFunctionAttribute" />.
+    /// </summary>
+    internal class DefaultMethodCallTranslatorProvider : IMethodCallTranslatorProvider
+    {
+
+        #region Static
+
+        private static readonly Dictionary<MethodInfo, IMethodCallTranslator> Registry = CreateDefaultRegistry();
+
+        private static Dictionary<MethodInfo, IMethodCallTranslator> CreateDefaultRegistry()
+        {
+            var query = typeof(DefaultMethodCallTranslatorProvider).GetTypeInfo().Assembly
+                .GetTypes()
+                .Where(
+                    type =>
+                        type.GetTypeInfo().IsClass && !type.GetTypeInfo().IsAbstract &&
+                        typeof (IMethodCallTranslator).IsAssignableFrom(type) &&
+                        type.GetConstructor(Type.EmptyTypes) != null)
+                .SelectMany(type =>
+                {
+                    var instance = (IMethodCallTranslator) Activator.CreateInstance(type);
+
+                    return instance.SupportMethods
+                        .Where(method => method != null)
+                        .Select(method => new {instance, method});
+                });
+
+            return query.ToDictionary(p => p.method, p => p.instance);
+        }
+
+        #endregion
+
+        public IMethodCallTranslator GetTranslator(MethodCallExpression methodCallExpression)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            return GetItem(methodCallExpression.Method);
+        }
+
+        protected virtual IMethodCallTranslator GetItem(MethodInfo key)
+        {
+            lock (Registry)
+            {
+                if (key == null)
+                {
+                    throw new ArgumentNullException("key");
+                }
+
+                IMethodCallTranslator translator;
+                if (Registry.TryGetValue(key, out translator))
+                {
+                    return translator;
+                }
+
+                if (key.IsGenericMethod && !key.IsGenericMethodDefinition)
+                {
+                    if (Registry.TryGetValue(key.GetGenericMethodDefinition(), out translator))
+                    {
+                        return translator;
+                    }
+                }
+
+                // Check if the generic form of the declaring type matches
+                translator = GetItemFromGenericType(key);
+                if (translator != null)
+                {
+                    return translator;
+                }
+
+                // Check any interfaces that may have a matching method
+                translator = GetItemFromInterfaces(key);
+                if (translator != null)
+                {
+                    return translator;
+                }
+
+                // If no preregistered method is found, check to see if the method is decorated with N1QlFunctionAttribute
+                translator = CreateFromN1QlFunctionAttribute(key);
+                if (translator != null)
+                {
+                    // Save this translator for reuse
+                    Registry.Add(key, translator);
+
+                    return translator;
+                }
+
+                // Finally, check base method if this is a virtual method
+                var baseMethod = key.GetBaseDefinition();
+                if ((baseMethod != null) && (baseMethod != key))
+                {
+                    return GetItem(baseMethod);
+                }
+
+                // No match found
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Checks the generic version of the type that implements the key method to see if it has an IMethodCallTranslator defined
+        /// </summary>
+        /// <param name="key">MethodInfo to test</param>
+        /// <returns>Null if no IMethodCallTranslator is found</returns>
+        protected virtual IMethodCallTranslator GetItemFromGenericType(MethodInfo key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException("key");
+            }
+
+            if ((key.DeclaringType == null) ||
+                (!key.DeclaringType.GetTypeInfo().IsGenericType || key.DeclaringType.GetTypeInfo().IsGenericTypeDefinition))
+            {
+                return null;
+            }
+
+            var genericType = key.DeclaringType.GetGenericTypeDefinition();
+            var classTypeArgs = key.DeclaringType.GetGenericArguments();
+
+            var methodTypeArgs = key.IsGenericMethod && !key.IsGenericMethodDefinition
+                ? key.GetGenericArguments()
+                : null;
+
+            var bindingFlags = (key.IsStatic ? BindingFlags.Static : BindingFlags.Instance) |
+                               (key.IsPublic ? BindingFlags.Public : BindingFlags.NonPublic);
+
+            var genericTypeKey = genericType.GetMethods(bindingFlags)
+                .FirstOrDefault(method =>
+                    method.Name == key.Name && ArgsMatch(key.GetParameters(), method, classTypeArgs, methodTypeArgs));
+
+            if (genericTypeKey != null)
+            {
+                IMethodCallTranslator translator;
+
+                lock (Registry)
+                {
+                    if (Registry.TryGetValue(genericTypeKey, out translator))
+                    {
+                        return translator;
+                    }
+
+                    if (genericTypeKey.IsGenericMethod && !genericTypeKey.IsGenericMethodDefinition)
+                    {
+                        if (Registry.TryGetValue(genericTypeKey.GetGenericMethodDefinition(), out translator))
+                        {
+                            return translator;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Checks all interfaces that implement the key method to see if one of them has an IMethodCallTranslator defined
+        /// </summary>
+        /// <param name="key">MethodInfo to test.  Must be an instance method on a class.</param>
+        /// <returns>Null if no IMethodCallTranslator is found</returns>
+        protected virtual IMethodCallTranslator GetItemFromInterfaces(MethodInfo key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException("key");
+            }
+
+            if (key.IsStatic || (key.DeclaringType == null) || (!key.DeclaringType.GetTypeInfo().IsClass))
+            {
+                return null;
+            }
+
+            foreach (var interfaceType in key.DeclaringType.GetInterfaces())
+            {
+                var interfaceMap = key.DeclaringType.GetTypeInfo().GetRuntimeInterfaceMap(interfaceType);
+
+                var matchedMapping = interfaceMap.TargetMethods
+                    .Select((p, i) => new {ClassMethod = p, InterfaceMethod = interfaceMap.InterfaceMethods[i]})
+                    .FirstOrDefault(p => p.ClassMethod == key);
+
+                if (matchedMapping != null)
+                {
+                    var translator = GetItem(matchedMapping.InterfaceMethod);
+                    if (translator != null)
+                    {
+                        return translator;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static bool ArgsMatch(ParameterInfo[] args, MethodInfo method, Type[] classTypeArgs, Type[] methodTypeArgs)
+        {
+            if (!method.IsGenericMethodDefinition && (methodTypeArgs != null))
+            {
+                return false;
+            }
+
+            if (method.IsGenericMethodDefinition)
+            {
+                if ((methodTypeArgs == null) || (methodTypeArgs.Length != method.GetGenericArguments().Length))
+                {
+                    return false;
+                }
+
+                method = method.MakeGenericMethod(methodTypeArgs);
+            }
+
+            var methodArgs = method.GetParameters();
+            if (methodArgs.Length != args.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < args.Length; i++)
+            {
+                var parameterType = methodArgs[i].ParameterType;
+                if (parameterType.IsGenericParameter)
+                {
+                    // This parameter is a generic from the class (not a method generic), so convert before comparing
+                    var genericArgs = method.DeclaringType.GetGenericArguments();
+
+                    for (var genericIndex = 0; genericIndex < genericArgs.Length; genericIndex++)
+                    {
+                        if (genericArgs[genericIndex] == parameterType)
+                        {
+                            parameterType = classTypeArgs[genericIndex];
+                            break;
+                        }
+                    }
+                }
+
+                if (!parameterType.IsAssignableFrom(args[i].ParameterType))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Checks for <see cref="N1QlFunctionAttribute" /> and creates a new <see cref="N1QlFunctionMethodCallTranslator" />
+        /// if it is found.  If not found, returns null.
+        /// </summary>
+        protected virtual IMethodCallTranslator CreateFromN1QlFunctionAttribute(MethodInfo key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException("key");
+            }
+
+            var attribute = key.GetCustomAttribute<N1QlFunctionAttribute>(true);
+
+            return attribute == null
+                ? null
+                : new N1QlFunctionMethodCallTranslator(key, attribute);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/ExpressionTransformers/DateTimeComparisonExpressionTransformer.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/ExpressionTransformers/DateTimeComparisonExpressionTransformer.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators;
+using Couchbase.EntityFramework.Serialization;
+using Couchbase.EntityFramework.Serialization.Converters;
+using Couchbase.Linq.Serialization;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
+
+namespace Couchbase.EntityFramework.QueryGeneration.ExpressionTransformers
+{
+    /// <summary>
+    /// Converts any DateTime constants or properties to Unix milliseconds before comparing them.
+    /// This way the <see cref="SerializationConverterMethodCallTranslator">SerializationConverterMethodCallTranslator</see>
+    /// will later interpret the calls as STR_TO_MILLIS() calls in N1QL.  N1QL can't accurately compare ISO8601
+    /// date/time values unless they're converted to Unix milliseconds first.
+    /// </summary>
+    internal class DateTimeComparisonExpressionTransformer : IExpressionTransformer<BinaryExpression>
+    {
+        private static readonly UnixMillisecondsSerializationConverter Converter = new UnixMillisecondsSerializationConverter();
+
+        private static readonly HashSet<Type> Types = new HashSet<Type>
+        {
+            typeof(DateTime),
+            typeof(DateTime?),
+            typeof(DateTimeOffset),
+            typeof(DateTimeOffset?)
+        };
+
+        private static readonly HashSet<MethodInfo> ConversionMethods = new HashSet<MethodInfo>(
+            Types.Select(type => typeof(ISerializationConverter<>).MakeGenericType(type).GetMethod("ConvertTo", new[] {type})));
+        private static readonly HashSet<MethodInfo> InverseConversionMethods = new HashSet<MethodInfo>(
+            Types.Select(type => typeof(ISerializationConverter<>).MakeGenericType(type).GetMethod("ConvertFrom", new[] {type})));
+
+        private static readonly ExpressionType[] StaticSupportedExpressionTypes =
+        {
+            ExpressionType.GreaterThan,
+            ExpressionType.GreaterThanOrEqual,
+            ExpressionType.LessThan,
+            ExpressionType.LessThanOrEqual,
+            ExpressionType.Equal,
+            ExpressionType.NotEqual
+        };
+
+        public ExpressionType[] SupportedExpressionTypes => StaticSupportedExpressionTypes;
+
+        public Expression Transform(BinaryExpression expression)
+        {
+            if ((expression.Left is MethodCallExpression leftMethodCall && ConversionMethods.Contains(leftMethodCall.Method)) ||
+                (expression.Right is MethodCallExpression rightMethodCall && ConversionMethods.Contains(rightMethodCall.Method)))
+            {
+                // One side is already converted, which means SerializationExpressionTreeVisitor already did the conversion
+                // So we can skip it
+
+                return expression;
+            }
+
+            if (expression.Right is ConstantExpression constantExpression && constantExpression.Value == null)
+            {
+                // Testing for null, so don't do transformation unless the inner expression is already converted
+                // In that case, drop the conversion to simplify the output query.
+
+                if (expression.Left is MethodCallExpression methodCallExpression &&
+                    InverseConversionMethods.Contains(methodCallExpression.Method))
+                {
+                    return expression.Update(
+                        methodCallExpression.Arguments[0],
+                        expression.Conversion,
+                        expression.Right);
+                }
+
+                return expression;
+            }
+
+            return expression.Update(
+                TransformSide(expression.Left),
+                expression.Conversion,
+                TransformSide(expression.Right));
+        }
+
+        private Expression TransformSide(Expression side)
+        {
+            if (!Types.Contains(side.Type))
+            {
+                return side;
+            }
+
+            if (side is MethodCallExpression methodCallExpression &&
+                ConversionMethods.Contains(methodCallExpression.Method))
+            {
+                // Avoid infinite recursion, don't apply changes if we did it previously
+                return side;
+            }
+
+            return Converter.GenerateConvertToExpression(side);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/ExpressionTransformers/EnumComparisonExpressionTransformer.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/ExpressionTransformers/EnumComparisonExpressionTransformer.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.Utils;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
+
+namespace Couchbase.EntityFramework.QueryGeneration.ExpressionTransformers
+{
+    /// <summary>
+    /// Recognizes == and != comparisons between a enumeration property and an enumeration constant.
+    /// By default, LINQ does this comparison using the base type of the enumeration, converting the
+    /// enumeration property to the base type and comparing to the raw number.  This converts the
+    /// comparison to be directly between two values of the enumeration type.  This allows
+    /// <see cref="N1QlExpressionTreeVisitor"/> to handle different serialization approaches for the
+    /// enumeration constant.
+    /// </summary>
+    internal class EnumComparisonExpressionTransformer : IExpressionTransformer<BinaryExpression>
+    {
+        public ExpressionType[] SupportedExpressionTypes
+        {
+            get
+            {
+                return new[]
+                {
+                    ExpressionType.Equal,
+                    ExpressionType.NotEqual
+                };
+            }
+        }
+
+        public Expression Transform(BinaryExpression expression)
+        {
+            Expression newExpression = null;
+
+            ConstantExpression constant;
+            if (IsEnumConversion(expression.Left) &&
+                (constant = ReflectionUtils.UnwrapNullableConversion<ConstantExpression>(expression.Right, out _)) != null)
+            {
+                newExpression = MakeEnumComparisonExpression(
+                    ((UnaryExpression) expression.Left).Operand,
+                    constant.Value,
+                    expression.NodeType);
+            }
+            else if (IsEnumConversion(expression.Right) &&
+                     (constant = ReflectionUtils.UnwrapNullableConversion<ConstantExpression>(expression.Left, out _)) != null)
+            {
+                newExpression = MakeEnumComparisonExpression(
+                    ((UnaryExpression)expression.Right).Operand,
+                    constant.Value,
+                    expression.NodeType);
+            }
+
+            return newExpression ?? expression;
+        }
+
+        private bool IsEnumConversion(Expression expression)
+        {
+            if (expression.NodeType != ExpressionType.Convert)
+            {
+                return false;
+            }
+
+            var convertExpression = (UnaryExpression) expression;
+            var type = convertExpression.Operand.Type;
+
+            // If type is Nullable<T>, extract the inner type to see if it is an enumeration
+            if (type.GetTypeInfo().IsGenericType && (type.GetGenericTypeDefinition() == typeof(Nullable<>)))
+            {
+                type = type.GetGenericArguments()[0];
+            }
+
+            return type.GetTypeInfo().IsEnum;
+        }
+
+        private BinaryExpression MakeEnumComparisonExpression(Expression operand, object enumValue,
+            ExpressionType comparisonType)
+        {
+            var isNullable = false;
+            var enumType = operand.Type;
+
+            // If type is Nullable<T>, the inner type is the enumeration type
+            if (enumType.GetTypeInfo().IsGenericType && (enumType.GetGenericTypeDefinition() == typeof (Nullable<>)))
+            {
+                enumType = enumType.GetGenericArguments()[0];
+                isNullable = true;
+            }
+
+            string name = null;
+            if (enumValue != null)
+            {
+                // enumValue == null if this is a Nullable type and it doesn't have a value
+
+                name = Enum.GetName(enumType, enumValue);
+
+                if (name == null)
+                {
+                    // Don't bother converting for undefined enumeration values, we'll use the original expression instead
+
+                    return null;
+                }
+            }
+
+            Expression comparisonValue;
+
+            if (name != null)
+            {
+                comparisonValue = Expression.Constant(enumType.GetField(name).GetValue(null));
+
+                if (isNullable)
+                {
+                    comparisonValue = Expression.Convert(comparisonValue, typeof(Nullable<>).MakeGenericType(enumType));
+                }
+            }
+            else
+            {
+                comparisonValue = Expression.Constant(null);
+            }
+
+            return Expression.MakeBinary(comparisonType, operand, comparisonValue);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/ExpressionTransformers/KeyExpressionTransfomer.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/ExpressionTransformers/KeyExpressionTransfomer.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
+
+namespace Couchbase.EntityFramework.QueryGeneration.ExpressionTransformers
+{
+    /// <summary>
+    /// Transforms references to the Key property of an IGrouping into another expression.
+    /// Used to convert references to the Key of a GroupBy statement to directly access the property
+    /// used to make the key.  This is done after a grouping subquery is flattened into the main N1QL query.
+    /// </summary>
+    internal class KeyExpressionTransfomer : IExpressionTransformer<MemberExpression>
+    {
+        public ExpressionType[] SupportedExpressionTypes
+        {
+            get
+            {
+                return new[]
+                {
+                    ExpressionType.MemberAccess
+                };
+            }
+        }
+
+        private readonly QuerySourceReferenceExpression _querySourceReference;
+        private readonly PropertyInfo _keyPropertyInfo;
+        private readonly Expression _replacementExpression;
+
+        /// <summary>
+        /// Creates a new KeyExpressionTransformer
+        /// </summary>
+        /// <param name="querySourceReference">QuerySourceReferenceExpression that references an IQuerySource returning an IGrouping</param>
+        /// <param name="replacementExpression">Expression to replace any reference to the Key property of the IGrouping</param>
+        public KeyExpressionTransfomer(QuerySourceReferenceExpression querySourceReference, Expression replacementExpression)
+        {
+            if (querySourceReference == null)
+            {
+                throw new ArgumentNullException("querySourceReference");
+            }
+            if (replacementExpression == null)
+            {
+                throw new ArgumentNullException("replacementExpression");
+            }
+
+            _querySourceReference = querySourceReference;
+            _keyPropertyInfo = querySourceReference.ReferencedQuerySource.ItemType.GetProperty("Key");
+            _replacementExpression = replacementExpression;
+        }
+
+        public Expression Transform(MemberExpression expression)
+        {
+            if (expression.Expression.Equals(_querySourceReference) && (expression.Member == _keyPropertyInfo))
+            {
+                return _replacementExpression;
+            }
+
+            return expression;
+        }
+
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/ExpressionTransformers/MultiKeyExpressionTransfomer.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/ExpressionTransformers/MultiKeyExpressionTransfomer.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
+
+namespace Couchbase.EntityFramework.QueryGeneration.ExpressionTransformers
+{
+    /// <summary>
+    /// Transforms references to the Key property of an IGrouping into another expression.
+    /// Used to convert references to the Key of a GroupBy statement to directly access the properties
+    /// used to make the key.  This is done after a grouping subquery is flattened into the main N1QL query.
+    /// The MultiKeyExpressionTransformer variant is used for multipart keys, where accessing members of the Key property.
+    /// </summary>
+    internal class MultiKeyExpressionTransfomer : IExpressionTransformer<MemberExpression>
+    {
+        public ExpressionType[] SupportedExpressionTypes
+        {
+            get
+            {
+                return new[]
+                {
+                    ExpressionType.MemberAccess
+                };
+            }
+        }
+
+        private readonly QuerySourceReferenceExpression _querySourceReference;
+        private readonly PropertyInfo _keyPropertyInfo;
+        private readonly NewExpression _newExpression;
+
+        /// <summary>
+        /// Creates a new KeyExpressionTransformer
+        /// </summary>
+        /// <param name="querySourceReference">QuerySourceReferenceExpression that references an IQuerySource returning an IGrouping</param>
+        /// <param name="newExpression">NewExpression which was used to create the multipart key for grouping</param>
+        public MultiKeyExpressionTransfomer(QuerySourceReferenceExpression querySourceReference, NewExpression newExpression)
+        {
+            if (querySourceReference == null)
+            {
+                throw new ArgumentNullException("querySourceReference");
+            }
+            if (newExpression == null)
+            {
+                throw new ArgumentNullException("newExpression");
+            }
+
+            _querySourceReference = querySourceReference;
+            _keyPropertyInfo = querySourceReference.ReferencedQuerySource.ItemType.GetProperty("Key");
+            _newExpression = newExpression;
+        }
+
+        public Expression Transform(MemberExpression expression)
+        {
+            var keyExpression = expression.Expression as MemberExpression;
+            
+            if ((keyExpression != null) && keyExpression.Expression.Equals(_querySourceReference)
+                && (keyExpression.Member == _keyPropertyInfo))
+            {
+                for (var i = 0; i < _newExpression.Members.Count; i++)
+                {
+                    if (_newExpression.Members[i] == expression.Member)
+                    {
+                        return _newExpression.Arguments[i];
+                    }
+                }
+            }
+
+            return expression;
+        }
+
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/ExpressionTransformers/StringComparisonExpressionTransformer.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/ExpressionTransformers/StringComparisonExpressionTransformer.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.QueryGeneration.Expressions;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
+
+namespace Couchbase.EntityFramework.QueryGeneration.ExpressionTransformers
+{
+    /// <summary>
+    /// Recognizes <see cref="string.Compare(string, string)"/> method calls, and converts them to
+    /// <see cref="StringComparisonExpression"/> expressions.
+    /// </summary>
+    internal class StringComparisonExpressionTransformer : IExpressionTransformer<BinaryExpression>
+    {
+        private static readonly MethodInfo[] StringCompareMethods = {
+           typeof(string).GetMethod("Compare", new[] { typeof(string), typeof(string) }),
+           typeof (string).GetMethod("Compare", new[] { typeof (string), typeof(string), typeof(StringComparison) }),
+           typeof(string).GetMethod("CompareTo", new[] { typeof(string) })
+        };
+
+        public ExpressionType[] SupportedExpressionTypes
+        {
+            get { return StringComparisonExpression.SupportedOperations; }
+        }
+
+        /// <summary>
+        /// Converts <see cref="string.Compare(string, string)"/> expressions to a
+        /// <see cref="StringComparisonExpression"/>, if applicable
+        /// </summary>
+        /// <param name="expression">BinaryExpression to test and convert</param>
+        /// <returns>If not a String.Compare expression, returns the original expression.  Otherwise the converted expression.</returns>
+        /// <remarks>
+        /// Converts String.Compare and String.CompareTo clauses where compared to an integer.
+        /// i.e. String.Compare(x, y) &lt; 0 or x.CompareTo(y) &lt; 0 are both the equivalent of x &lt; y
+        /// </remarks>
+        public Expression Transform(BinaryExpression expression)
+        {
+            // See if one side is a call to String.Compare
+
+            var leftExpression = expression.Left as MethodCallExpression;
+            var rightExpression = expression.Right as MethodCallExpression;
+            ConstantExpression comparisonExpression = null;
+
+            if ((leftExpression != null) && !StringCompareMethods.Contains(leftExpression.Method))
+            {
+                leftExpression = null;
+            }
+            if ((rightExpression != null) && !StringCompareMethods.Contains(rightExpression.Method))
+            {
+                rightExpression = null;
+            }
+
+            var methodCallExpression = leftExpression ?? rightExpression;
+
+            if (methodCallExpression == null)
+            {
+                // Not a string comparison
+                return expression;
+            }
+
+            // Get the number side of the comparison, which must be a constant integer
+
+            var numericExpression = leftExpression != null
+                ? expression.Right as ConstantExpression
+                : expression.Left as ConstantExpression;
+
+            if ((numericExpression == null) || !typeof(int).IsAssignableFrom(numericExpression.Type))
+            {
+                // Only convert if comparing to an integer
+                return expression;
+            }
+
+            var number = (int)numericExpression.Value;
+
+            // Get the strings from the method call parameters
+
+            Expression leftString;
+            Expression rightString;
+            if (methodCallExpression.Arguments.Count > 2)
+            {
+                leftString = methodCallExpression.Arguments[0];
+                rightString = methodCallExpression.Arguments[1];
+                comparisonExpression = methodCallExpression.Arguments[2] as ConstantExpression;
+            }
+            else if (methodCallExpression.Arguments.Count > 1)
+            {
+                leftString = methodCallExpression.Arguments[0];
+                rightString = methodCallExpression.Arguments[1];
+            }
+            else
+            {
+                leftString = methodCallExpression.Object;
+                rightString = methodCallExpression.Arguments[0];
+            }
+
+            if (leftExpression == null)
+            {
+                // If the method call is on the right side of the binary expression, then reverse the strings
+
+                var temp = leftString;
+                leftString = rightString;
+                rightString = temp;
+            }
+
+            return ConvertStringCompareExpression(leftString, rightString, expression.NodeType, number, comparisonExpression);
+        }
+
+        /// <summary>
+        /// Converts String.Compare expression to StringComparisonExpression
+        /// </summary>
+        /// <param name="leftString">String expression on the left side of the comparison</param>
+        /// <param name="rightString">String expression on the right side of the comparison</param>
+        /// <param name="operation">Comparison operation being performed</param>
+        /// <param name="number">Number that String.Compare was being compared to, typically 0, 1, or -1.</param>
+        /// <param name="comparisonExpression">Indicated the comparison type. Most commonly used with case insensitive comparisons</param>
+        private Expression ConvertStringCompareExpression(Expression leftString, Expression rightString,
+            ExpressionType operation, int number, ConstantExpression comparisonExpression)
+        {
+            if (number == 1)
+            {
+                if ((operation == ExpressionType.LessThan) || (operation == ExpressionType.NotEqual))
+                {
+                    operation = ExpressionType.LessThanOrEqual;
+                }
+                else if ((operation == ExpressionType.Equal || operation == ExpressionType.GreaterThanOrEqual))
+                {
+                    operation = ExpressionType.GreaterThan;
+                }
+                else
+                {
+                    // Always evaluates to true or false regardless of input, so return a constant expression
+                    return Expression.Constant(operation == ExpressionType.LessThanOrEqual,
+                        typeof(bool));
+                }
+            }
+            else if (number == -1)
+            {
+                if ((operation == ExpressionType.GreaterThan) || (operation == ExpressionType.NotEqual))
+                {
+                    operation = ExpressionType.GreaterThanOrEqual;
+                }
+                else if ((operation == ExpressionType.Equal || operation == ExpressionType.LessThanOrEqual))
+                {
+                    operation = ExpressionType.LessThan;
+                }
+                else
+                {
+                    // Always evaluates to true or false regardless of input, so return a constant expression
+                    return Expression.Constant(operation == ExpressionType.GreaterThanOrEqual, typeof(bool));
+                }
+            }
+            else if (number > 1)
+            {
+                // Always evaluates to true or false regardless of input, so return a constant expression
+                return Expression.Constant(
+                    (operation == ExpressionType.NotEqual) || (operation == ExpressionType.LessThan) || (operation == ExpressionType.LessThanOrEqual),
+                    typeof(bool));
+            }
+            else if (number < -1)
+            {
+                // Always evaluates to true or false regardless of input, so return a constant expression
+                return Expression.Constant(
+                    (operation == ExpressionType.NotEqual) || (operation == ExpressionType.GreaterThan) || (operation == ExpressionType.GreaterThanOrEqual),
+                    typeof(bool));
+            }
+
+            // If number == 0 we just leave operation unchanged
+            StringComparison? comparison = null;
+            if (comparisonExpression != null)
+            {
+                comparison = (StringComparison)comparisonExpression.Value;
+                if (comparison != StringComparison.Ordinal && comparison != StringComparison.OrdinalIgnoreCase)
+                {
+                    var msg = string.Format("String comparison option {0} is not supported", comparison);
+                    throw new NotSupportedException(msg);
+                }
+            }
+
+            return StringComparisonExpression.Create(operation, leftString, rightString, comparison);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/Expressions/StringComparisonExpression.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/Expressions/StringComparisonExpression.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Couchbase.EntityFramework.QueryGeneration.Expressions
+{
+    /// <summary>
+    /// Represents a comparison between two strings
+    /// </summary>
+    internal class StringComparisonExpression : Expression
+    {
+
+        public static readonly ExpressionType[] SupportedOperations =
+        {
+            ExpressionType.Equal,
+            ExpressionType.NotEqual,
+            ExpressionType.LessThan,
+            ExpressionType.LessThanOrEqual,
+            ExpressionType.GreaterThan,
+            ExpressionType.GreaterThanOrEqual
+        };
+
+        public ExpressionType Operation { get; private set; }
+        public Expression Left { get; private set; }
+        public Expression Right { get; private set; }
+        public StringComparison? Comparison { get; set; }
+
+        public override ExpressionType NodeType
+        {
+            get
+            {
+                return ExpressionType.Extension;
+            }
+        }
+
+        public override Type Type
+        {
+            get { return typeof(bool); }
+        }
+
+        public static StringComparisonExpression Create(ExpressionType operation, Expression left, Expression right, StringComparison? comparison = null)
+        {
+            if (!SupportedOperations.Contains(operation))
+            {
+                throw new ArgumentOutOfRangeException("operation");
+            }
+            if (left == null)
+            {
+                throw new ArgumentNullException("left");
+            }
+            if (right == null)
+            {
+                throw new ArgumentNullException("right");
+            }
+            if (left.Type != typeof(string))
+            {
+                throw new ArgumentException("Expressions must be strings.", "left");
+            }
+            if (right.Type != typeof(string))
+            {
+                throw new ArgumentException("Expressions must be strings.", "right");
+            }
+
+            return new StringComparisonExpression(operation, left, right, comparison);
+        }
+
+        private StringComparisonExpression(ExpressionType operation, Expression left, Expression right, StringComparison? comparison = null)
+        {
+            Operation = operation;
+            Left = left;
+            Right = right;
+            Comparison = comparison;
+        }
+
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var newLeft = visitor.Visit(Left);
+            var newRight = visitor.Visit(Right);
+
+            if ((Left != newLeft) || (Right != newRight))
+            {
+                return Create(Operation, newLeft, newRight, Comparison);
+            }
+            else
+            {
+                return this;
+            }
+        }
+
+        public override string ToString()
+        {
+            return string.Format("{0} {1} {2}",
+                Left,
+                Operation,
+                Right);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/FromParts/AnsiJoinPart.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/FromParts/AnsiJoinPart.cs
@@ -1,0 +1,47 @@
+﻿using System.Text;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.EntityFramework.QueryGeneration.FromParts
+{
+    /// <summary>
+    /// Represents the FROM part of a query with a full ANSI JOIN clause.
+    /// </summary>
+    internal class AnsiJoinPart : JoinPart
+    {
+        /// <summary>
+        /// Outer key selector.
+        /// </summary>
+        public string OuterKey { get; set; }
+
+        /// <summary>
+        /// Inner key selector.
+        /// </summary>
+        public string InnerKey { get; set; }
+
+        /// <summary>
+        /// Join operator, defaults to "="
+        /// </summary>
+        public string Operator { get; set; } = "=";
+
+        /// <summary>
+        /// Additional predicates to apply to the inner sequence.
+        /// </summary>
+        public string AdditionalInnerPredicates { get; set; }
+
+        public AnsiJoinPart(IQuerySource querySource) : base(querySource)
+        {
+        }
+
+        public override void AppendToStringBuilder(StringBuilder sb)
+        {
+            base.AppendToStringBuilder(sb);
+
+            sb.AppendFormat(" ON ({0} {1} {2})", OuterKey, Operator, InnerKey);
+
+            if (!string.IsNullOrEmpty(AdditionalInnerPredicates))
+            {
+                sb.AppendFormat(" AND {0}", AdditionalInnerPredicates);
+            }
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/FromParts/ExtentPart.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/FromParts/ExtentPart.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Couchbase.EntityFramework.Clauses;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.EntityFramework.QueryGeneration.FromParts
+{
+    /// <summary>
+    /// Represents an extent of the query.
+    /// </summary>
+    internal abstract class ExtentPart
+    {
+        private IQuerySource _querySource;
+
+        /// <summary>
+        /// Clause which is the source of the query data, such as a MainFromClause.
+        /// </summary>
+        public IQuerySource QuerySource
+        {
+            get => _querySource;
+            set => _querySource = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        /// <summary>
+        /// Source of the query data, such as a bucket name.  Should already be escaped.
+        /// </summary>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// Name of the query data when being referenced in the query ("as" clause).  Should already be escaped.
+        /// </summary>
+        public string ItemName { get; set; }
+
+        public List<HintClause> Hints { get; set; }
+
+        protected ExtentPart(IQuerySource querySource)
+        {
+            QuerySource = querySource ?? throw new ArgumentNullException(nameof(querySource));
+        }
+
+        public virtual void AppendToStringBuilder(StringBuilder sb)
+        {
+            // Use a single format string for performance
+
+            if (Hints != null && Hints.Any())
+            {
+                sb.AppendFormat(" {0} as {1} USE ",
+                    Source,
+                    ItemName);
+
+                for (var i = 0; i < Hints.Count; i++)
+                {
+                    if (i > 0)
+                    {
+                        sb.Append(' ');
+                    }
+
+                    Hints[i].AppendToStringBuilder(sb);
+                }
+            }
+            else
+            {
+                sb.AppendFormat(" {0} as {1}",
+                    Source,
+                    ItemName);
+            }
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/FromParts/FromPart.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/FromParts/FromPart.cs
@@ -1,0 +1,22 @@
+﻿using System.Text;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.EntityFramework.QueryGeneration.FromParts
+{
+    /// <summary>
+    /// Represents the FROM part of a query
+    /// </summary>
+    internal class FromPart : ExtentPart
+    {
+        public FromPart(IQuerySource querySource) : base(querySource)
+        {
+        }
+
+        public override void AppendToStringBuilder(StringBuilder sb)
+        {
+            sb.Append(" FROM");
+
+            base.AppendToStringBuilder(sb);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/FromParts/IndexJoinPart.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/FromParts/IndexJoinPart.cs
@@ -1,0 +1,32 @@
+﻿using System.Text;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.EntityFramework.QueryGeneration.FromParts
+{
+    /// <summary>
+    /// Represents the FROM part of a query with an index JOIN clause.
+    /// </summary>
+    internal class IndexJoinPart : JoinPart
+    {
+        /// <summary>
+        /// For joins, the expression for the key value to join
+        /// </summary>
+        public string OnKeys { get; set; }
+
+        /// <summary>
+        /// For index joins, the name of the extent on the left side of the join.  Should already be escaped.
+        /// </summary>
+        public string IndexJoinExtentName { get; set; }
+
+        public IndexJoinPart(IQuerySource querySource) : base(querySource)
+        {
+        }
+
+        public override void AppendToStringBuilder(StringBuilder sb)
+        {
+            base.AppendToStringBuilder(sb);
+
+            sb.AppendFormat(" ON KEY {0} FOR {1}", OnKeys, IndexJoinExtentName);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/FromParts/JoinPart.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/FromParts/JoinPart.cs
@@ -1,0 +1,28 @@
+﻿using System.Text;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.EntityFramework.QueryGeneration.FromParts
+{
+    /// <summary>
+    /// Represents the FROM part of a query with a JOIN, NEST, or UNNEST clause
+    /// </summary>
+    internal class JoinPart : ExtentPart
+    {
+        /// <summary>
+        /// Type of join to perform
+        /// </summary>
+        public string JoinType { get; set; }
+
+        public JoinPart(IQuerySource querySource) : base(querySource)
+        {
+        }
+
+        public override void AppendToStringBuilder(StringBuilder sb)
+        {
+            sb.Append(' ');
+            sb.Append(JoinType);
+
+            base.AppendToStringBuilder(sb);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/FromParts/JoinTypes.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/FromParts/JoinTypes.cs
@@ -1,0 +1,12 @@
+﻿namespace Couchbase.EntityFramework.QueryGeneration.FromParts
+{
+    internal static class JoinTypes
+    {
+        public const string InnerJoin = "INNER JOIN";
+        public const string LeftJoin = "LEFT JOIN";
+        public const string InnerNest = "INNER NEST";
+        public const string LeftNest = "LEFT OUTER NEST";
+        public const string InnerUnnest = "INNER UNNEST";
+        public const string LeftUnnest = "LEFT OUTER UNNEST";
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/FromParts/OnKeysJoinPart.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/FromParts/OnKeysJoinPart.cs
@@ -1,0 +1,27 @@
+﻿using System.Text;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.EntityFramework.QueryGeneration.FromParts
+{
+    /// <summary>
+    /// Represents the FROM part of a query with an ON KEYS based JOIN clause.
+    /// </summary>
+    internal class OnKeysJoinPart : JoinPart
+    {
+        /// <summary>
+        /// For joins, the expression for the key value to join
+        /// </summary>
+        public string OnKeys { get; set; }
+
+        public OnKeysJoinPart(IQuerySource querySource) : base(querySource)
+        {
+        }
+
+        public override void AppendToStringBuilder(StringBuilder sb)
+        {
+            base.AppendToStringBuilder(sb);
+
+            sb.AppendFormat(" ON KEYS {0}", OnKeys);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/IMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/IMethodCallTranslator.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration
+{
+    internal interface IMethodCallTranslator
+    {
+        IEnumerable<MethodInfo> SupportMethods { get; }
+
+        Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor);
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/IMethodCallTranslatorProvider.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/IMethodCallTranslatorProvider.cs
@@ -1,0 +1,9 @@
+﻿using System.Linq.Expressions;
+
+namespace Couchbase.EntityFramework.QueryGeneration
+{
+    internal interface IMethodCallTranslatorProvider
+    {
+        IMethodCallTranslator GetTranslator(MethodCallExpression methodCallExpression);
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/IN1QlExpressionTreeVisitor.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/IN1QlExpressionTreeVisitor.cs
@@ -1,0 +1,23 @@
+﻿using System.Linq.Expressions;
+using System.Text;
+
+namespace Couchbase.EntityFramework.QueryGeneration
+{
+    /// <summary>
+    /// Expression tree visitor which builds a N1QL expression from the tree.
+    /// </summary>
+    public interface IN1QlExpressionTreeVisitor
+    {
+        /// <summary>
+        /// N1QL query being built.
+        /// </summary>
+        StringBuilder Expression { get; }
+
+        /// <summary>
+        /// Visits a node in the expression tree and any child nodes, rendering
+        /// them onto the <see cref="Expression"/>.
+        /// </summary>
+        /// <param name="expression">Node to visit.</param>
+        void Visit(Expression expression);
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/IN1QlQueryModelVisitor.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/IN1QlQueryModelVisitor.cs
@@ -1,0 +1,14 @@
+﻿using Couchbase.EntityFramework.Clauses;
+using Remotion.Linq;
+
+namespace Couchbase.EntityFramework.QueryGeneration
+{
+    internal interface IN1QlQueryModelVisitor : IQueryModelVisitor
+    {
+        void VisitNestClause(NestClause clause, QueryModel queryModel, int index);
+
+        void VisitUseKeysClause(UseKeysClause clause, QueryModel queryModel, int index);
+
+        void VisitHintClause(HintClause clause, QueryModel queryModel, int index);
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/InnerNestDetectingExpressionVisitor.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/InnerNestDetectingExpressionVisitor.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Couchbase.EntityFramework.QueryGeneration.FromParts;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ResultOperators;
+using Remotion.Linq.Parsing;
+
+namespace Couchbase.EntityFramework.QueryGeneration
+{
+    /// <summary>
+    /// Processes the predicate of a <see cref="WhereClause"/> to find .Any() subqueries
+    /// against group join (NEST) extents.  If found, converts the group join from a
+    /// LEFT NEST to an INNER NEST and drops the subquery from the predicate.
+    /// </summary>
+    internal class InnerNestDetectingExpressionVisitor : RelinqExpressionVisitor
+    {
+        private readonly QueryPartsAggregator _queyPartsAggregator;
+
+        /// <summary>
+        /// Creates a new InnerNestDetectingExpressionVisitor.
+        /// </summary>
+        /// <param name="queyPartsAggregator"><see cref="QueryPartsAggregator"/> for the current query.</param>
+        public InnerNestDetectingExpressionVisitor(QueryPartsAggregator queyPartsAggregator)
+        {
+            _queyPartsAggregator = queyPartsAggregator ?? throw new ArgumentNullException(nameof(queyPartsAggregator));
+        }
+
+        protected override Expression VisitBinary(BinaryExpression node)
+        {
+            if (node.NodeType == ExpressionType.AndAlso)
+            {
+                var left = Visit(node.Left);
+                var right = Visit(node.Right);
+
+                if (left != null && right != null)
+                {
+                    if (left.Equals(node.Left) && right.Equals(node.Right))
+                    {
+                        // Was not modified
+                        return node;
+                    }
+                    else
+                    {
+                        // One of the sides was modified, so build a replacement binary expression
+                        return Expression.MakeBinary(node.NodeType, left, right, node.IsLiftedToNull,
+                            node.Method, node.Conversion);
+                    }
+                }
+                else if (left != null)
+                {
+                    // Right side was dropped
+                    return left;
+                }
+                else
+                {
+                    // Left side or both sides were dropped
+                    return right;
+                }
+            }
+            else
+            {
+                // Don't recurse into anything other than &&
+                return node;
+            }
+        }
+
+        protected override Expression VisitSubQuery(SubQueryExpression expression)
+        {
+            var queryModel = expression.QueryModel;
+
+            if (!IsSimpleAnySubqueryAgainstGroupJoin(queryModel, out var groupJoinClause))
+            {
+                // We don't care about subqueries with any body clauses
+                return expression;
+            }
+
+            // See if this group join is a LEFT OUTER NEST
+            var ansiJoinPart = _queyPartsAggregator.Extents.OfType<AnsiJoinPart>()
+                .FirstOrDefault(p => p.QuerySource == groupJoinClause);
+
+            if (ansiJoinPart != null && ansiJoinPart.JoinType == JoinTypes.LeftNest)
+            {
+                // Convert from a LEFT OUTER NEST to an INNER NEST
+                ansiJoinPart.JoinType = JoinTypes.InnerNest;
+
+                // And drop the expression from the WHERE clause
+                return null;
+            }
+            else
+            {
+                return expression;
+            }
+        }
+
+        private static bool IsSimpleAnySubqueryAgainstGroupJoin(QueryModel queryModel, out GroupJoinClause groupJoinClause)
+        {
+            groupJoinClause = null;
+
+            if (queryModel.BodyClauses.Count > 0)
+            {
+                return false;
+            }
+
+            if (queryModel.ResultOperators.Count != 1)
+            {
+                return false;
+            }
+
+            if (!(queryModel.ResultOperators[0] is AnyResultOperator))
+            {
+                return false;
+            }
+
+            if (queryModel.MainFromClause.FromExpression is QuerySourceReferenceExpression referenceExpression)
+            {
+                groupJoinClause = referenceExpression.ReferencedQuerySource as GroupJoinClause;
+
+                return groupJoinClause != null;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/LinqQueryRequest.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/LinqQueryRequest.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.Execution;
+using Couchbase.Linq;
+using Couchbase.N1QL;
+using Remotion.Linq.Parsing.ExpressionVisitors;
+
+namespace Couchbase.EntityFramework.QueryGeneration
+{
+    /// <summary>
+    /// Wraps a standard QueryRequest with some additional information used internally.
+    /// </summary>
+    internal class LinqQueryRequest : QueryRequest
+    {
+        private readonly ScalarResultBehavior _scalarResultBehavior;
+
+        /// <summary>
+        /// If true, indicates that the result of the query is wrapped in an object with a single property, named "result".
+        /// After execution, this property should be extracted from the wrapper object.
+        /// </summary>
+        public ScalarResultBehavior ScalarResultBehavior
+        {
+            get { return _scalarResultBehavior; }
+        }
+
+        /// <summary>
+        /// For queries returning a single result, true indicates that an empty result set should return the default value.
+        /// For example, a call to .FirstOrDefault() would set this to true.
+        /// </summary>
+        public bool ReturnDefaultWhenEmpty { get; set; }
+
+        /// <summary>
+        /// Creates a new LinqQueryRequest, with the given N1QL query.
+        /// </summary>
+        /// <param name="query">N1QL query.</param>
+        /// <param name="scalarResultBehavior">Behaviors related to extracting results for scalar queries.</param>
+        public LinqQueryRequest(string query, ScalarResultBehavior scalarResultBehavior)
+            : base(query)
+        {
+            if (scalarResultBehavior == null)
+            {
+                throw new ArgumentNullException("scalarResultBehavior");
+            }
+
+            _scalarResultBehavior = scalarResultBehavior;
+        }
+
+        #region Conversion Helpers
+
+        private static readonly MethodInfo ToQueryRequestMethodInfo =
+            typeof(LinqQueryRequest).GetMethod("ToQueryRequest", BindingFlags.NonPublic | BindingFlags.Static);
+
+        /// <summary>
+        /// Convert a LINQ query against a Couchbase bucket to a <see cref="LinqQueryRequest"/>.
+        /// </summary>
+        /// <typeparam name="T">The target type.</typeparam>
+        /// <param name="source">The query to be converted.  This must be a query based on a Couchbase bucket.</param>
+        /// <returns><see cref="LinqQueryRequest"/> containing the N1QL query.</returns>
+        internal static LinqQueryRequest CreateQueryRequest<T>(IQueryable<T> source)
+        {
+            return CreateQueryRequest<T, IQueryable<T>>(source, null);
+        }
+
+        /// <summary>
+        /// Convert a LINQ query against a Couchbase bucket to a <see cref="LinqQueryRequest"/>.
+        /// </summary>
+        /// <typeparam name="T">The target type.</typeparam>
+        /// <typeparam name="TResult">The type of the result returned by additionalExpresion.</typeparam>
+        /// <param name="source">The query to be converted.  This must be a query based on a Couchbase bucket.</param>
+        /// <param name="additionalExpression">Additional expressions to apply to the query before making a LinqQueryRequest.  Typically used for aggregates.</param>
+        /// <returns><see cref="LinqQueryRequest"/> containing the N1QL query.</returns>
+        internal static LinqQueryRequest CreateQueryRequest<T, TResult>(IQueryable<T> source,
+            Expression<Func<IQueryable<T>, TResult>> additionalExpression)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException("source");
+            }
+            if (!(source is IBucketQueryable))
+            {
+                throw new ArgumentException("CreateQueryRequest is only supported on Couchbase LINQ queries.", "source");
+            }
+
+            Expression sourceExpression = source.Expression;
+
+            if (additionalExpression != null)
+            {
+                sourceExpression = ReplacingExpressionVisitor.Replace(
+                    additionalExpression.Parameters[0],
+                    sourceExpression,
+                    additionalExpression.Body);
+            }
+
+            // Now wrap the completed query in a call to ToQueryRequest
+            // This will trigger the creation of a ToQueryRequestResultOperator when building the QueryModel
+
+            var newExpression = Expression.Call(null,
+                ToQueryRequestMethodInfo.MakeGenericMethod(typeof(TResult)),
+                sourceExpression);
+
+            return source.Provider.Execute<LinqQueryRequest>(newExpression);
+        }
+
+        internal static LinqQueryRequest ToQueryRequest<TResult>(TResult source)
+        {
+            throw new NotImplementedException("ToQueryRequest should only be used to build expression trees, not executed.");
+        }
+
+        #endregion
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MemberNameResolvers/ExtendedTypeSerializerMemberNameResolver.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MemberNameResolvers/ExtendedTypeSerializerMemberNameResolver.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Reflection;
+using Couchbase.Core.Serialization;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MemberNameResolvers
+{
+    /// <summary>
+    /// Implementation of <see cref="IMemberNameResolver"/> which uses an <see cref="IExtendedTypeSerializer"/>
+    /// to resolve member names.
+    /// </summary>
+    internal class ExtendedTypeSerializerMemberNameResolver : IMemberNameResolver
+    {
+        private readonly IExtendedTypeSerializer _serializer;
+
+        public ExtendedTypeSerializerMemberNameResolver(IExtendedTypeSerializer serializer)
+        {
+            if (serializer == null)
+            {
+                throw new ArgumentNullException("serializer");
+            }
+
+            _serializer = serializer;
+        }
+
+        public bool TryResolveMemberName(MemberInfo member, out string memberName)
+        {
+            memberName = null;
+
+            if (member == null)
+                return false;
+
+            memberName = _serializer.GetMemberName(member);
+
+            return memberName != null;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MemberNameResolvers/IMemberNameResolver.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MemberNameResolvers/IMemberNameResolver.cs
@@ -1,0 +1,9 @@
+﻿using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MemberNameResolvers
+{
+    internal interface IMemberNameResolver
+    {
+        bool TryResolveMemberName(MemberInfo member, out string memberName);
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MemberNameResolvers/JsonNetMemberNameResolver.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MemberNameResolvers/JsonNetMemberNameResolver.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json.Serialization;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MemberNameResolvers
+{
+    /// <summary>
+    /// Implementation of <see cref="IMemberNameResolver"/> which uses a Newtonsoft.Json
+    /// <see cref="IContractResolver"/> to resolve member names.
+    /// </summary>
+    /// <remarks>
+    /// Used for backwards compatibility with older implementations of <see cref="Couchbase.Core.Serialization.ITypeSerializer"/>
+    /// which don't have a GetMemberName implementation like <see cref="Couchbase.Core.Serialization.IExtendedTypeSerializer"/>.
+    /// </remarks>
+    internal class JsonNetMemberNameResolver : IMemberNameResolver
+    {
+        private readonly IContractResolver _contractResolver;
+
+        public JsonNetMemberNameResolver(IContractResolver contractResolver)
+        {
+            if (contractResolver == null)
+            {
+                throw new ArgumentNullException("contractResolver");
+            }
+
+            _contractResolver = contractResolver;
+        }
+
+        public bool TryResolveMemberName(MemberInfo member, out string memberName)
+        {
+            memberName = null;
+
+            if (member == null)
+                return false;
+
+            var contract = _contractResolver.ResolveContract(member.DeclaringType);
+
+            if (contract.GetType() == typeof (JsonObjectContract) &&
+                ((JsonObjectContract) contract).Properties.Any(p => p.UnderlyingName == member.Name && !p.Ignored))
+            {
+                memberName =
+                    ((JsonObjectContract) contract).Properties.First(p => p.UnderlyingName == member.Name).PropertyName;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/ConcatMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/ConcatMethodCallTranslator.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class ConcatMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic = {
+            typeof (string).GetMethod("Concat", new[] { typeof (object) }),
+            typeof (string).GetMethod("Concat", new[] { typeof (object), typeof (object) }),
+            typeof (string).GetMethod("Concat", new[] { typeof (object), typeof (object), typeof (object) }),
+            typeof (string).GetMethod("Concat", new[] { typeof (string), typeof (string) }),
+            typeof (string).GetMethod("Concat", new[] { typeof (string), typeof (string), typeof (string) }),
+            typeof (string).GetMethod("Concat", new[] { typeof (string), typeof (string), typeof (string), typeof (string) }),
+            typeof (string).GetMethod("Concat", new[] { typeof (object[]) }),
+            typeof (string).GetMethod("Concat", new[] { typeof (string[]) }),
+            typeof (string).GetMethod("Concat", new[] { typeof (IEnumerable<string>) }),
+            typeof (string).GetMethods().Single (mi => mi.Name == "Concat" && mi.IsGenericMethod && mi.GetGenericArguments().Length == 1)
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expression.Append('(');
+
+            bool first = true;
+            foreach (var argument in GetConcatenatedItems(methodCallExpression))
+            {
+                if (first)
+                {
+                    first = false;
+                }
+                else
+                {
+                    expression.Append(" || ");
+                }
+
+                expressionTreeVisitor.Visit(argument);
+            }
+
+            expression.Append(')');
+
+            return methodCallExpression;
+        }
+
+        private IEnumerable<Expression> GetConcatenatedItems(MethodCallExpression methodCallExpression)
+        {
+            if (methodCallExpression.Arguments.Count == 1
+                && (typeof(IEnumerable).IsAssignableFrom(methodCallExpression.Arguments[0].Type)
+                    && methodCallExpression.Arguments[0].Type != typeof(string)))
+            {
+                ConstantExpression argumentAsConstantExpression;
+                NewArrayExpression argumentAsNewArrayExpression;
+
+                if ((argumentAsNewArrayExpression = methodCallExpression.Arguments[0] as NewArrayExpression) != null)
+                {
+                    return argumentAsNewArrayExpression.Expressions;
+                }
+                else if ((argumentAsConstantExpression = methodCallExpression.Arguments[0] as ConstantExpression) != null)
+                {
+                    return ((object[])argumentAsConstantExpression.Value).Select(element => (Expression)Expression.Constant(element));
+                }
+                else
+                {
+                    var message = string.Format(
+                        "The method call '{0}' is not supported. When the array overloads of String.Concat are used, only constant or new array expressions can "
+                        + "be translated to SQL; in this usage, the expression has type '{1}'.",
+                        methodCallExpression,
+                        methodCallExpression.Arguments[0].GetType());
+                    throw new NotSupportedException(message);
+                }
+            }
+            else
+            {
+                return methodCallExpression.Arguments;
+            }
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/ContainsMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/ContainsMethodCallTranslator.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class ContainsMethodCallTranslator : IMethodCallTranslator
+    {
+        private const string Contains = "Contains";
+        private const string StartsWith = "StartsWith";
+        private const string EndsWith = "EndsWith";
+
+        private static readonly MethodInfo[] SupportedMethodsStatic =
+        {
+            typeof(string).GetMethod(Contains, new[] {typeof(string)}),
+            typeof(string).GetMethod(StartsWith, new[] {typeof(string)}),
+            typeof(string).GetMethod(EndsWith, new[] {typeof(string)})
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+            if (expressionTreeVisitor == null)
+            {
+                throw new ArgumentNullException("expressionTreeVisitor");
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expression.Append("(");
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expression.Append(" LIKE ");
+
+            var constantExpression = methodCallExpression.Arguments[0] as ConstantExpression;
+            if ((constantExpression != null) && (constantExpression.Type == typeof(string)) &&
+                (constantExpression.Value != null))
+            {
+                // This is a string constant, so we can build the literal in advance
+
+                var newExpression = Expression.Constant(
+                    (methodCallExpression.Method.Name != StartsWith ? "%" : "") +
+                    constantExpression.Value +
+                    (methodCallExpression.Method.Name != EndsWith ? "%" : ""));
+
+                expressionTreeVisitor.Visit(newExpression);
+            }
+            else
+            {
+                // The argument is dynamic, so we must build the comparison in N1QL
+
+                if (methodCallExpression.Method.Name != StartsWith)
+                {
+                    expression.Append("'%' || ");
+                }
+
+                expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
+
+                if (methodCallExpression.Method.Name != EndsWith)
+                {
+                    expression.Append(" || '%'");
+                }
+            }
+
+            expression.Append(')');
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/DictionaryContainsKeyMethodCallTranslator .cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/DictionaryContainsKeyMethodCallTranslator .cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class DictionaryContainsKeyMethodCallTranslator  : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic = {
+            typeof (IDictionary).GetMethod("Contains"),
+            typeof (IDictionary<,>).GetMethod("ContainsKey")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods => SupportedMethodsStatic;
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException(nameof(methodCallExpression));
+            }
+
+            if (methodCallExpression.Arguments[0] is ConstantExpression keyExpression)
+            {
+                var expression = expressionTreeVisitor.Expression;
+
+                expressionTreeVisitor.Visit(methodCallExpression.Object);
+                expression.Append('.');
+                expression.Append(N1QlHelpers.EscapeIdentifier(keyExpression.Value.ToString()));
+                expression.Append(" IS NOT MISSING");
+            }
+            else
+            {
+                throw new NotSupportedException("Dictionary keys must be constants");
+            }
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/DictionaryItemMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/DictionaryItemMethodCallTranslator.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class DictionaryItemMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic = {
+            typeof (IDictionary).GetMethod("get_Item"),
+            typeof (IDictionary<,>).GetMethod("get_Item")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods => SupportedMethodsStatic;
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            if (methodCallExpression.Arguments[0] is ConstantExpression keyExpression)
+            {
+                var expression = expressionTreeVisitor.Expression;
+
+                expressionTreeVisitor.Visit(methodCallExpression.Object);
+                expression.Append('.');
+                expression.Append(N1QlHelpers.EscapeIdentifier(keyExpression.Value.ToString()));
+            }
+            else
+            {
+                throw new NotSupportedException("Dictionary keys must be constants");
+            }
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/DictionaryKeysMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/DictionaryKeysMethodCallTranslator.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class DictionaryKeysMethodCallTranslator  : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic = {
+            typeof (IDictionary).GetMethod("get_Keys"),
+            typeof (IDictionary<,>).GetMethod("get_Keys"),
+            typeof (Dictionary<,>).GetMethod("get_Keys")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods => SupportedMethodsStatic;
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException(nameof(methodCallExpression));
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expression.Append("OBJECT_NAMES(");
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expression.Append(')');
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/DictionaryValuesMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/DictionaryValuesMethodCallTranslator.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class DictionaryValuesMethodCallTranslator  : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic = {
+            typeof (IDictionary).GetMethod("get_Values"),
+            typeof (IDictionary<,>).GetMethod("get_Values"),
+            typeof (Dictionary<,>).GetMethod("get_Values")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods => SupportedMethodsStatic;
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException(nameof(methodCallExpression));
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expression.Append("OBJECT_VALUES(");
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expression.Append(')');
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/IsMissingMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/IsMissingMethodCallTranslator.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class IsMissingMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic =
+            typeof (N1QlFunctions).GetMethods().Where(p => (p.Name == "IsMissing") || (p.Name == "IsNotMissing")).ToArray();
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
+
+            if (methodCallExpression.Arguments.Count > 1)
+            {
+                var constantExpression = methodCallExpression.Arguments[1] as ConstantExpression;
+                if (constantExpression == null)
+                {
+                    throw new NotSupportedException("IsMissing and IsNotMissing propertyName parameter must be a constant");
+                }
+
+                expression.AppendFormat(".{0}",
+                    N1QlHelpers.EscapeIdentifier(constantExpression.Value.ToString()));
+            }
+
+            expression.Append(methodCallExpression.Method.Name == "IsMissing" ? " IS MISSING" : " IS NOT MISSING");
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/IsValuedMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/IsValuedMethodCallTranslator.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class IsValuedMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic =
+            typeof (N1QlFunctions).GetMethods().Where(p => (p.Name == "IsValued") || (p.Name == "IsNotValued")).ToArray();
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
+
+            if (methodCallExpression.Arguments.Count > 1)
+            {
+                var constantExpression = methodCallExpression.Arguments[1] as ConstantExpression;
+                if (constantExpression == null)
+                {
+                    throw new NotSupportedException("IsValued and IsNotValued propertyName parameter must be a constant");
+                }
+
+                expression.AppendFormat(".{0}",
+                    N1QlHelpers.EscapeIdentifier(constantExpression.Value.ToString()));
+            }
+
+            expression.Append(methodCallExpression.Method.Name == "IsValued" ? " IS VALUED" : " IS NOT VALUED");
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/KeyMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/KeyMethodCallTranslator.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class KeyMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic = {
+            typeof (N1QlFunctions).GetMethod("Key")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+            if (expressionTreeVisitor == null)
+            {
+                throw new ArgumentNullException("expressionTreeVisitor");
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expression.Append("META(");
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
+            expression.Append(").id");
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/ListIndexMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/ListIndexMethodCallTranslator.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class ListIndexMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic = {
+            typeof (IList).GetMethod("get_Item"),
+            typeof (IList<>).GetMethod("get_Item")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expression.Append('[');
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
+            expression.Append(']');
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/MathMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/MathMethodCallTranslator.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class MathMethodCallTranslator : IMethodCallTranslator
+    {
+        /// <summary>
+        /// Maps System.Math method call names to N1QL functions
+        /// </summary>
+        private static readonly Dictionary<String, String> SupportedMethodNames =
+            new Dictionary<String, String> 
+        {
+            {"Abs", "ABS"},
+            {"Acos", "ACOS"},
+            {"Atan", "ATAN"},
+            {"Atan2", "ATAN2"},
+            {"Asin", "ASIN"},
+            {"Ceiling", "CEIL"},
+            {"Cos", "COS"},
+            {"Exp", "EXP"},
+            {"Floor", "FLOOR"},
+            {"Log", "LN"},
+            {"Log10", "LOG"},
+            {"Pow", "POWER"},
+            {"Round", "ROUND"},
+            {"Sign", "SIGN"},
+            {"Sin", "SIN"},
+            {"Sqrt", "SQRT"},
+            {"Tan", "TAN"},
+            {"Truncate", "TRUNC"}
+        };
+
+        /// <summary>
+        /// Returns all numeric types for parameters of System.Math method overloads
+        /// </summary>
+        /// <returns></returns>
+        private static IEnumerable<Type> GetNumericTypes()
+        {
+            yield return typeof (byte);
+            yield return typeof (sbyte);
+            yield return typeof (short);
+            yield return typeof (ushort);
+            yield return typeof (int);
+            yield return typeof (uint);
+            yield return typeof (long);
+            yield return typeof (ulong);
+            yield return typeof (decimal);
+            yield return typeof (float);
+            yield return typeof (double);
+        }
+
+        /// <summary>
+        /// Given a parameter type, get all supported methods on System.Math that accept this parameter type
+        /// </summary>
+        private static IEnumerable<MethodInfo> GetMathMethodsForType(Type t)
+        {
+            // Find methods which are in the SupportedMethodNames dictionary
+            // And where all parameter types match t
+
+            var methods = typeof (Math).GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Where(method => SupportedMethodNames.Keys.Contains(method.Name));
+
+            foreach (MethodInfo method in methods.Where(method => method.GetParameters().All(parameter => parameter.ParameterType == t)))
+            {
+                yield return method;
+            }
+
+            if ((t == typeof (decimal)) || (t == typeof (double)))
+            {
+                // Also need to pickup Math.Round with a single integer second parameter
+                yield return typeof (Math).GetMethod("Round", new Type[] {t, typeof (int)});
+            }
+        } 
+
+        private static readonly MethodInfo[] SupportedMethodsStatic =
+            GetNumericTypes().SelectMany(GetMathMethodsForType).ToArray();
+            
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            string functionName;
+            if (!SupportedMethodNames.TryGetValue(methodCallExpression.Method.Name, out functionName))
+            {
+                throw new NotSupportedException("Unsupported Math Method");
+            }
+
+            expression.AppendFormat("{0}(", functionName);
+
+            for (var i=0; i<methodCallExpression.Arguments.Count; i++)
+            {
+                if (i > 0)
+                {
+                    expression.Append(", ");
+                }
+
+                expressionTreeVisitor.Visit(methodCallExpression.Arguments[i]);
+            }
+            
+            expression.Append(')');
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/MetaMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/MetaMethodCallTranslator.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class MetaMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic = {
+            typeof (N1QlFunctions).GetMethod("Meta")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expression.Append("META(");
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
+            expression.Append(')');
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/N1QlFunctionMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/N1QlFunctionMethodCallTranslator.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    /// <summary>
+    /// Translates calls to static methods decorated with <see cref="N1QlFunctionAttribute" />.
+    /// </summary>
+    internal class N1QlFunctionMethodCallTranslator : IMethodCallTranslator
+    {
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get { return new[] { MethodInfo }; }
+        }
+
+        public MethodInfo MethodInfo { get; private set; }
+        public string N1QlFunctionName { get; private set; }
+
+        /// <summary>
+        /// Creates a new N1QlFunctionMethodCallTranslator for a given method and <see cref="N1QlFunctionAttribute"/>.
+        /// </summary>
+        /// <param name="methodInfo">Method call to be translated.  Must be a static method.</param>
+        /// <param name="attribute"><see cref="N1QlFunctionAttribute"/> that defines the translation.</param>
+        public N1QlFunctionMethodCallTranslator(MethodInfo methodInfo, N1QlFunctionAttribute attribute)
+        {
+            if (methodInfo == null)
+            {
+                throw new ArgumentNullException("methodInfo");
+            }
+            if (!methodInfo.IsStatic)
+            {
+                throw new ArgumentException("Only static methods are supported", "methodInfo");
+            }
+            if (attribute == null)
+            {
+                throw new ArgumentNullException("attribute");
+            }
+
+            MethodInfo = methodInfo;
+            N1QlFunctionName = attribute.N1QlFunctionName;
+        }
+
+        /// <summary>
+        /// Translate the given method call expression.
+        /// </summary>
+        /// <param name="methodCallExpression">Method call to be translated.  Must match the method provided to the constructor.</param>
+        /// <param name="expressionTreeVisitor"><see cref="N1QlExpressionTreeVisitor"/> to use to visit parameters.</param>
+        /// <returns>Original or altered expression.</returns>
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+            if (expressionTreeVisitor == null)
+            {
+                throw new ArgumentNullException("expressionTreeVisitor");
+            }
+            if (methodCallExpression.Method != MethodInfo)
+            {
+                throw new ArgumentException("Cannot translate a method other than the one provided to the constructor.", "methodCallExpression");
+            }
+
+            expressionTreeVisitor.Expression.Append(N1QlFunctionName);
+            expressionTreeVisitor.Expression.Append('(');
+
+            for (var i = 0; i < methodCallExpression.Arguments.Count; i++)
+            {
+                if (i > 0)
+                {
+                    expressionTreeVisitor.Expression.Append(", ");
+                }
+
+                expressionTreeVisitor.Visit(methodCallExpression.Arguments[i]);
+            }
+
+            expressionTreeVisitor.Expression.Append(')');
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/SerializationConverterMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/SerializationConverterMethodCallTranslator.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.Serialization;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class SerializationConverterMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic =
+        {
+            typeof (ISerializationConverter<>).GetMethod("ConvertTo"),
+            typeof (ISerializationConverter<>).GetMethod("ConvertFrom")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods => SupportedMethodsStatic;
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException(nameof(methodCallExpression));
+            }
+            if (expressionTreeVisitor == null)
+            {
+                throw new ArgumentNullException(nameof(expressionTreeVisitor));
+            }
+
+            if (methodCallExpression.Object is ConstantExpression constantExpression
+                && constantExpression.Value is ISerializationConverter conversion)
+            {
+                if (methodCallExpression.Method.Name == "ConvertTo")
+                {
+                    conversion.RenderConvertTo(methodCallExpression.Arguments[0], expressionTreeVisitor);
+                }
+                else
+                {
+                    conversion.RenderConvertFrom(methodCallExpression.Arguments[0], expressionTreeVisitor);
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    "Invalid attempt to process ISerializationConverter<T> method call.");
+            }
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/StringCapitalizationMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/StringCapitalizationMethodCallTranslator.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class StringCapitalizationMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic =
+        {
+            typeof (string).GetMethod("ToUpper", Type.EmptyTypes),
+            typeof (string).GetMethod("ToLower", Type.EmptyTypes)
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expression.Append(methodCallExpression.Method.Name == "ToLower" ? "LOWER(" : "UPPER(");
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expression.Append(")");
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/StringIndexOfMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/StringIndexOfMethodCallTranslator.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class StringIndexOfMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic =
+        {
+            typeof (string).GetMethod("IndexOf", new[] { typeof (char) }),
+            typeof (string).GetMethod("IndexOf", new[] { typeof (string) })
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expression.Append("POSITION(");
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expression.Append(", ");
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
+            expression.Append(")");
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/StringLengthMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/StringLengthMethodCallTranslator.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class StringLengthMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic =
+        {
+            typeof (string).GetMethod("get_Length")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expression.Append("LENGTH(");
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expression.Append(")");
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/StringReplaceMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/StringReplaceMethodCallTranslator.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class StringReplaceMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic =
+        {
+            typeof (string).GetMethod("Replace", new[] { typeof (char), typeof(char) }),
+            typeof (string).GetMethod("Replace", new[] { typeof (string), typeof(string) })
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expression.Append("REPLACE(");
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expression.Append(", ");
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
+            expression.Append(", ");
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[1]);
+            expression.Append(")");
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/StringSplitMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/StringSplitMethodCallTranslator.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class StringSplitMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic =
+        {
+            typeof (string).GetMethod("Split", new[] { typeof (char[]) })
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expression.Append("SPLIT(");
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
+
+            if (methodCallExpression.Arguments[0].Type != typeof(char[]))
+            {
+                throw new NotSupportedException("String Split Operations Expect Character Array Parameters");
+            }
+
+            try
+            {
+                var lambda = Expression.Lambda<Func<char[]>>(methodCallExpression.Arguments[0]).Compile();
+                var chars = lambda.Invoke();
+
+                if ((chars != null) && (chars.Length > 0))
+                {
+                    if (chars.Length > 1)
+                    {
+                        throw new NotSupportedException("Cannot Split With More Than One Character");
+                    }
+
+                    expression.Append(", ");
+
+                    expressionTreeVisitor.Visit(Expression.Constant(chars[0], typeof(char)));
+                }
+            }
+            catch (NotSupportedException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new NotSupportedException("Unable To Parse Split Character Set.  Dynamic Expressions Are Not Supported", ex);
+            }
+
+            expression.Append(")");
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/StringTrimMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/StringTrimMethodCallTranslator.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class StringTrimMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic =
+        {
+            typeof (string).GetMethod("Trim", Type.EmptyTypes),
+            typeof (string).GetMethod("Trim", new[] { typeof (char[]) }),
+            typeof (string).GetMethod("TrimStart", Type.EmptyTypes),
+            typeof (string).GetMethod("TrimEnd", Type.EmptyTypes),
+            typeof (string).GetMethod("TrimStart", new [] { typeof(char[])}),
+            typeof (string).GetMethod("TrimEnd", new [] { typeof(char[])}),
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expression.Append(methodCallExpression.Method.Name == "TrimStart" ? "LTRIM(" :
+                methodCallExpression.Method.Name == "TrimEnd" ? "RTRIM(" : "TRIM(");
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
+
+            if (methodCallExpression.Arguments.Count > 0)
+            {
+                if (methodCallExpression.Arguments[0].Type != typeof (char[]))
+                {
+                    throw new NotSupportedException("String Trim Operations Expect Character Array Parameters");
+                }
+
+                try
+                {
+                    var lambda = Expression.Lambda<Func<char[]>>(methodCallExpression.Arguments[0]).Compile();
+                    var chars = lambda.Invoke();
+
+                    if ((chars != null) && (chars.Length > 0))
+                    {
+                        expression.Append(", ");
+
+                        expressionTreeVisitor.Visit(Expression.Constant(new String(chars), typeof (string)));
+                    }
+                }
+                catch (NotSupportedException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    throw new NotSupportedException("Unable To Parse Trim Character Set.  Dynamic Expressions Are Not Supported", ex);
+                }
+            }
+
+            expression.Append(")");
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/SubqueryMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/SubqueryMethodCallTranslator.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class SubqueryMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic =
+        {
+            typeof (Enumerable).GetMethod("ToArray"),
+            typeof (Enumerable).GetMethod("ToList"),
+            typeof (Enumerable).GetMethod("AsEnumerable")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            // Do not process ToArray, ToList, or AsEnumerable.  Instead just visit the list in the first argument.
+
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/SubstringMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/SubstringMethodCallTranslator.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class SubstringMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic =
+        {
+            typeof (string).GetMethod("Substring", new[] { typeof (int) }),
+            typeof (string).GetMethod("Substring", new[] { typeof (int), typeof(int) }),
+            typeof (string).GetMethod("get_Chars", new[] { typeof (int) })
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+
+            var expression = expressionTreeVisitor.Expression;
+
+            expression.Append("SUBSTR(");
+            expressionTreeVisitor.Visit(methodCallExpression.Object);
+            expression.Append(", ");
+            expressionTreeVisitor.Visit(methodCallExpression.Arguments[0]);
+
+            if (methodCallExpression.Arguments.Count > 1)
+            {
+                expression.Append(", ");
+                expressionTreeVisitor.Visit(methodCallExpression.Arguments[1]);
+            }
+            else if (methodCallExpression.Method.Name == "get_Chars")
+            {
+                // Called str[i], so return a single character at i
+                expression.Append(", 1");
+            }
+
+            expression.Append(")");
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/ToStringMethodCallTranslator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/MethodCallTranslators/ToStringMethodCallTranslator.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators
+{
+    internal class ToStringMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo[] SupportedMethodsStatic =
+        {
+            typeof (object).GetMethod("ToString")
+        };
+
+        public IEnumerable<MethodInfo> SupportMethods
+        {
+            get
+            {
+                return SupportedMethodsStatic;
+            }
+        }
+
+        public Expression Translate(MethodCallExpression methodCallExpression, N1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (methodCallExpression == null)
+            {
+                throw new ArgumentNullException("methodCallExpression");
+            }
+            if (methodCallExpression.Object == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            if (methodCallExpression.Object.Type == typeof (string))
+            {
+                expressionTreeVisitor.Visit(methodCallExpression.Object);
+            }
+            else
+            {
+                var expression = expressionTreeVisitor.Expression;
+
+                expression.Append("TOSTRING(");
+                expressionTreeVisitor.Visit(methodCallExpression.Object);
+                expression.Append(")");
+            }
+
+            return methodCallExpression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/N1QLExpressionTreeVisitor.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/N1QLExpressionTreeVisitor.cs
@@ -1,0 +1,639 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using Couchbase.EntityFramework.QueryGeneration.Expressions;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Parsing;
+
+namespace Couchbase.EntityFramework.QueryGeneration
+{
+    internal class N1QlExpressionTreeVisitor : ThrowingExpressionVisitor, IN1QlExpressionTreeVisitor
+    {
+        private static readonly Assembly Mscorlib = typeof(string).GetTypeInfo().Assembly;
+
+        private readonly StringBuilder _expression = new StringBuilder();
+        public StringBuilder Expression => _expression;
+
+        public N1QlQueryGenerationContext QueryGenerationContext { get; }
+
+        protected N1QlExpressionTreeVisitor(N1QlQueryGenerationContext queryGenerationContext)
+        {
+            QueryGenerationContext = queryGenerationContext ?? throw new ArgumentNullException(nameof(queryGenerationContext));
+        }
+
+        public static string GetN1QlExpression(Expression expression, N1QlQueryGenerationContext queryGenerationContext)
+        {
+            var visitor = new N1QlExpressionTreeVisitor(queryGenerationContext);
+            visitor.Visit(expression);
+            return visitor.GetN1QlExpression();
+        }
+
+        public static string GetN1QlSelectNewExpression(Expression expression, N1QlQueryGenerationContext queryGenerationContext)
+        {
+            var visitor = new N1QlExpressionTreeVisitor(queryGenerationContext);
+            visitor.VisitSelectNewExpression(expression);
+            return visitor.GetN1QlExpression();
+        }
+
+        protected override Exception CreateUnhandledItemException<T>(T unhandledItem, string visitMethod)
+        {
+            // No longer using FormattingExpressionTreeVisitor to format unhandledItem if it is an Expression
+            // This visitor was removed in Relinq 2.0 as obsolete because ToString is now sufficient in .Net 4
+            // https://www.re-motion.org/jira/browse/RMLNQ-56
+
+            var message = string.Format(
+                "The expression '{0}' (type: {1}) is not supported by this LINQ provider."
+                , unhandledItem
+                , typeof(T));
+
+            return new NotSupportedException(message);
+        }
+
+        public string GetN1QlExpression()
+        {
+            return _expression.ToString();
+        }
+
+        /// <inheritdoc/>
+        void IN1QlExpressionTreeVisitor.Visit(Expression expression)
+        {
+            Visit(expression);
+        }
+
+        public override Expression Visit(Expression expression)
+        {
+            switch (expression.NodeType)
+            {
+                case ExpressionType.Coalesce:
+                    return VisitCoalesceExpression((BinaryExpression)expression);
+
+                case ExpressionType.ArrayIndex:
+                    return VisitArrayIndexExpression((BinaryExpression)expression);
+
+                default:
+                    return base.Visit(expression);
+            }
+        }
+
+        protected override Expression VisitExtension(Expression expression)
+        {
+            var stringComparison = expression as StringComparisonExpression;
+            if (stringComparison != null)
+            {
+                return VisitStringComparisonExpression(stringComparison);
+            }
+
+            return base.VisitExtension(expression);
+        }
+
+        protected override Expression VisitNew(NewExpression expression)
+        {
+            VisitNewObject(expression.Members, expression.Arguments);
+
+            return expression;
+        }
+
+        protected override Expression VisitMemberInit(MemberInitExpression expression)
+        {
+            if (expression.NewExpression.Arguments.Count > 0)
+            {
+                throw new NotSupportedException("New Objects Must Be Initialized With A Parameterless Constructor");
+            }
+            if (expression.Bindings.Any(p => p.BindingType != MemberBindingType.Assignment))
+            {
+                throw new NotSupportedException("New Objects Must Be Initialized With Assignments Only");
+            }
+
+            var arguments = expression.Bindings.Cast<MemberAssignment>().Select(p => p.Expression).ToList();
+            var members = expression.Bindings.Select(p => p.Member).ToList();
+
+            VisitNewObject(members, arguments);
+
+            return expression;
+        }
+
+        /// <summary>
+        /// Shared logic for NewExpression and MemberInitExpression
+        /// </summary>
+        private void VisitNewObject(IList<MemberInfo> members, IList<Expression> arguments)
+        {
+            _expression.Append('{');
+
+            for (var i = 0; i < members.Count; i++)
+            {
+                var beforeAppendLength = _expression.Length;
+
+                if (i > 0)
+                {
+                    _expression.Append(", ");
+                }
+
+                if (!QueryGenerationContext.MemberNameResolver.TryResolveMemberName(members[i], out var memberName))
+                {
+                    memberName = members[i].Name;
+                }
+
+                _expression.AppendFormat("\"{0}\": ", memberName);
+
+                var beforeSubExpressionLength = _expression.Length;
+
+                Visit(arguments[i]);
+
+                if (_expression.Length == beforeSubExpressionLength)
+                {
+                    // nothing was added for the value, so remove the part that was added originally
+                    _expression.Length = beforeAppendLength;
+                }
+            }
+
+            _expression.Append('}');
+        }
+
+        /// <summary>
+        /// Parses the new object that is part of the select expression with "as" based formatting.
+        /// Can accept either a NewExpression or MemberInitExpression
+        /// </summary>
+        private Expression VisitSelectNewExpression(Expression expression)
+        {
+            IList<Expression> arguments;
+            IList<MemberInfo> members;
+
+            var memberInitExpression = expression as MemberInitExpression;
+            if (memberInitExpression != null)
+            {
+                if (memberInitExpression.NewExpression.Arguments.Count > 0)
+                {
+                    throw new NotSupportedException("New Objects Must Be Initialized With A Parameterless Constructor");
+                }
+                if (memberInitExpression.Bindings.Any(p => p.BindingType != MemberBindingType.Assignment))
+                {
+                    throw new NotSupportedException("New Objects Must Be Initialized With Assignments Only");
+                }
+
+                arguments = memberInitExpression.Bindings.Cast<MemberAssignment>().Select(p => p.Expression).ToList();
+                members = memberInitExpression.Bindings.Select(p => p.Member).ToList();
+            }
+            else
+            {
+                var newExpression = expression as NewExpression;
+                if (newExpression == null)
+                {
+                    throw new NotSupportedException("Unsupported Select Clause Expression");
+                }
+
+                arguments = newExpression.Arguments;
+                members = newExpression.Members;
+            }
+
+            for (var i = 0; i < members.Count; i++)
+            {
+                if (i > 0)
+                {
+                    _expression.Append(", ");
+                }
+
+                var expressionLength = _expression.Length;
+
+                Visit(arguments[i]);
+
+                //only add 'as' part if the  previous visitexpression has generated something.
+                if (_expression.Length > expressionLength)
+                {
+                    if (!QueryGenerationContext.MemberNameResolver.TryResolveMemberName(members[i], out var memberName))
+                    {
+                        memberName = members[i].Name;
+                    }
+
+                    _expression.AppendFormat(" as {0}", N1QlHelpers.EscapeIdentifier(memberName));
+                }
+                else if (i > 0)
+                {
+                    // nothing was added, so remove the extra comma
+                    _expression.Length -= 2;
+                }
+            }
+
+            return expression;
+        }
+
+        protected override Expression VisitNewArray(NewArrayExpression expression)
+        {
+            if (expression.NodeType == ExpressionType.NewArrayInit)
+            {
+                _expression.Append('[');
+
+                for (var i = 0; i < expression.Expressions.Count; i++)
+                {
+                    if (i > 0)
+                    {
+                        _expression.Append(", ");
+                    }
+
+                    Visit(expression.Expressions[i]);
+                }
+
+                _expression.Append(']');
+
+                return expression;
+            }
+            else
+            {
+                return base.VisitNewArray(expression);
+            }
+        }
+
+        protected override Expression VisitBinary(BinaryExpression expression)
+        {
+            ConstantExpression constantExpression;
+
+            _expression.Append("(");
+
+            Visit(expression.Left);
+
+            //TODO: Refactor this to work in a nicer way. Maybe use lookup tables
+            switch (expression.NodeType)
+            {
+                case ExpressionType.Equal:
+                    constantExpression = expression.Right as ConstantExpression;
+                    if ((constantExpression != null) && (constantExpression.Value == null))
+                    {
+                        // short circuit normal path to use IS NULL operator
+                        _expression.Append(" IS NULL)");
+                        return expression;
+                    }
+                    else
+                    {
+                        _expression.Append(" = ");
+                    }
+                    break;
+
+                case ExpressionType.AndAlso:
+                case ExpressionType.And:
+                    _expression.Append(" AND ");
+                    break;
+
+                case ExpressionType.OrElse:
+                case ExpressionType.Or:
+                    _expression.Append(" OR ");
+                    break;
+
+                case ExpressionType.Add:
+                    if ((expression.Left.Type == typeof(string)) || (expression.Right.Type == typeof(string)))
+                    {
+                        _expression.Append(" || ");
+                    }
+                    else
+                    {
+                        _expression.Append(" + ");
+                    }
+                    break;
+
+                case ExpressionType.Subtract:
+                    _expression.Append(" - ");
+                    break;
+
+                case ExpressionType.Multiply:
+                    _expression.Append(" * ");
+                    break;
+
+                case ExpressionType.Divide:
+                    _expression.Append(" / ");
+                    break;
+
+                case ExpressionType.Modulo:
+                    _expression.Append(" % ");
+                    break;
+
+                case ExpressionType.GreaterThan:
+                    _expression.Append(" > ");
+                    break;
+
+                case ExpressionType.GreaterThanOrEqual:
+                    _expression.Append(" >= ");
+                    break;
+
+                case ExpressionType.LessThan:
+                    _expression.Append(" < ");
+                    break;
+
+                case ExpressionType.LessThanOrEqual:
+                    _expression.Append(" <= ");
+                    break;
+
+                case ExpressionType.NotEqual:
+                    constantExpression = expression.Right as ConstantExpression;
+                    if ((constantExpression != null) && (constantExpression.Value == null))
+                    {
+                        // short circuit normal path to use IS NOT NULL operator
+                        _expression.Append(" IS NOT NULL)");
+                        return expression;
+                    }
+                    else
+                    {
+                        _expression.Append(" != ");
+                    }
+                    break;
+
+                default:
+                    base.VisitBinary(expression);
+                    break;
+            }
+
+            Visit(expression.Right);
+            _expression.Append(")");
+
+            return expression;
+        }
+
+        #region String Comparison
+
+        protected virtual Expression VisitStringComparisonExpression(StringComparisonExpression expression)
+        {
+            var toLower = expression.Comparison.HasValue && expression.Comparison.Value == StringComparison.OrdinalIgnoreCase;
+
+            _expression.Append('(');
+            if (toLower)
+            {
+                _expression.Append("LOWER(");
+                Visit(expression.Left);
+                _expression.Append(')');
+            }
+            else
+            {
+                Visit(expression.Left);
+            }
+
+
+            switch (expression.Operation)
+            {
+                case ExpressionType.Equal:
+                    _expression.Append(" = ");
+                    break;
+                case ExpressionType.NotEqual:
+                    _expression.Append(" != ");
+                    break;
+                case ExpressionType.LessThan:
+                    _expression.Append(" < ");
+                    break;
+                case ExpressionType.LessThanOrEqual:
+                    _expression.Append(" <= ");
+                    break;
+                case ExpressionType.GreaterThan:
+                    _expression.Append(" > ");
+                    break;
+                case ExpressionType.GreaterThanOrEqual:
+                    _expression.Append(" >= ");
+                    break;
+            }
+
+            if (toLower)
+            {
+                _expression.Append("LOWER(");
+                Visit(expression.Right);
+                _expression.Append(')');
+            }
+            else
+            {
+                Visit(expression.Right);
+            }
+
+            _expression.Append(')');
+
+            return expression;
+        }
+
+        #endregion
+
+        /// <summary>
+        ///     Visits a coalese expression recursively, building a IFMISSINGORNULL function
+        /// </summary>
+        private Expression VisitCoalesceExpression(BinaryExpression expression)
+        {
+            _expression.Append("IFMISSINGORNULL(");
+            Visit(expression.Left);
+
+            var rightExpression = expression.Right;
+            while (rightExpression != null)
+            {
+                _expression.Append(", ");
+
+                if (rightExpression.NodeType == ExpressionType.Coalesce)
+                {
+                    var subExpression = (BinaryExpression)rightExpression;
+                    Visit(subExpression.Left);
+
+                    rightExpression = subExpression.Right;
+                }
+                else
+                {
+                    Visit(rightExpression);
+                    rightExpression = null;
+                }
+            }
+
+            _expression.Append(')');
+
+            return expression;
+        }
+
+        /// <summary>
+        ///     Special handling for ArrayIndex binary expressions
+        /// </summary>
+        protected virtual Expression VisitArrayIndexExpression(BinaryExpression expression)
+        {
+            Visit(expression.Left);
+            _expression.Append('[');
+            Visit(expression.Right);
+            _expression.Append(']');
+
+            return expression;
+        }
+
+        /// <summary>
+        ///     Tries to translate the Method-call to some N1QL expression. Currently only implemented for "Contains() - LIKE"
+        /// </summary>
+        /// <param name="expression"></param>
+        /// <returns></returns>
+        protected override Expression VisitMethodCall(MethodCallExpression expression)
+        {
+            IMethodCallTranslator methodCallTranslator = QueryGenerationContext.MethodCallTranslatorProvider.GetTranslator(expression);
+
+            if (methodCallTranslator != null)
+            {
+                return methodCallTranslator.Translate(expression, this);
+            }
+
+            return base.VisitMethodCall(expression);
+        }
+
+        protected override Expression VisitConstant(ConstantExpression expression)
+        {
+            var namedParameter = QueryGenerationContext.ParameterAggregator.AddNamedParameter(expression.Value);
+
+            if (namedParameter.Value == null)
+            {
+                _expression.Append("NULL");
+            }
+            else if (namedParameter.Value is string)
+            {
+                _expression.AppendFormat("'{0}'", namedParameter.Value.ToString().Replace("'", "''"));
+            }
+            else if (namedParameter.Value is char)
+            {
+                _expression.AppendFormat("'{0}'", (char)namedParameter.Value != '\'' ? namedParameter.Value : "''");
+            }
+            else if (namedParameter.Value is bool)
+            {
+                _expression.Append((bool)namedParameter.Value ? "TRUE" : "FALSE");
+            }
+            else if (namedParameter.Value is DateTime || namedParameter.Value is DateTimeOffset)
+            {
+                // For consistency, use the JSON serializer configured for the cluster
+                var serializedDateTime = QueryGenerationContext.Serializer.Serialize(namedParameter.Value);
+
+                _expression.Append(Encoding.UTF8.GetString(serializedDateTime));
+            }
+            else if (namedParameter.Value is System.Collections.IEnumerable)
+            {
+                _expression.Append('[');
+
+                bool first = true;
+                foreach (var element in (System.Collections.IEnumerable)namedParameter.Value)
+                {
+                    if (first)
+                    {
+                        first = false;
+                    }
+                    else
+                    {
+                        _expression.Append(", ");
+                    }
+
+                    VisitConstant(System.Linq.Expressions.Expression.Constant(element));
+                }
+
+                _expression.Append(']');
+            }
+            else if (namedParameter.Value.GetType().GetTypeInfo().IsEnum)
+            {
+                // Use the type serializer to format the value as JSON.
+                // This allows different serialization converters to work on the value.
+                // Then convert back to get the raw type being stored, such as a string or integer.
+                // Then we can write this value to N1QL by visiting it as a constant expression.
+
+                var jsonString = QueryGenerationContext.Serializer.Serialize(namedParameter.Value);
+                var jsonValue = QueryGenerationContext.Serializer.Deserialize<object>(jsonString, 0, jsonString.Length);
+
+                return Visit(System.Linq.Expressions.Expression.Constant(jsonValue));
+            }
+            else if (namedParameter.Value is Guid)
+            {
+                _expression.AppendFormat("'{0}'", namedParameter.Value.ToString());
+            }
+            else
+            {
+                // Use the invariant culture so that decimal handling is correct
+                _expression.Append(Convert.ToString(namedParameter.Value, System.Globalization.CultureInfo.InvariantCulture));
+            }
+
+            return expression;
+        }
+
+        protected override Expression VisitConditional(ConditionalExpression expression)
+        {
+            _expression.Append("CASE WHEN ");
+            Visit(expression.Test);
+            _expression.Append(" THEN ");
+            Visit(expression.IfTrue);
+            _expression.Append(" ELSE ");
+            Visit(expression.IfFalse);
+            _expression.Append(" END");
+
+            return expression;
+        }
+
+        protected override Expression VisitQuerySourceReference(QuerySourceReferenceExpression expression)
+        {
+            _expression.Append(QueryGenerationContext.ExtentNameProvider.GetExtentName(expression.ReferencedQuerySource));
+
+            return expression;
+        }
+
+        protected override Expression VisitMember(MemberExpression expression)
+        {
+            if (expression.Expression.Type.GetTypeInfo().Assembly.Equals(Mscorlib))
+            {
+                // For property getters on the core .Net classes, we don't want to just recurse through the .Net object model
+                // Instead, convert to a MethodCallExpression
+                // And it will pass through the appropriate IMethodCallTranslator
+                // (i.e. string.Length)
+
+                var propInfo = expression.Member as PropertyInfo;
+                if ((propInfo != null) && (propInfo.GetMethod != null) && (propInfo.GetMethod.GetParameters().Length == 0))
+                {
+                    // Convert to a property getter method call
+                    var newExpression = System.Linq.Expressions.Expression.Call(
+                        expression.Expression,
+                        propInfo.GetMethod);
+
+                    return Visit(newExpression);
+                }
+            }
+
+            if (QueryGenerationContext.MemberNameResolver.TryResolveMemberName(expression.Member, out var memberName))
+            {
+                var querySourceExpression = expression.Expression as QuerySourceReferenceExpression;
+                if ((querySourceExpression != null) &&
+                    (QueryGenerationContext.ExtentNameProvider.GetExtentName(
+                        querySourceExpression.ReferencedQuerySource) == ""))
+                {
+                    // This query source has a blank extent name, so we don't need to reference the extent to access the member
+
+                    _expression.Append(N1QlHelpers.EscapeIdentifier(memberName));
+                }
+                else
+                {
+                    Visit(expression.Expression);
+                    _expression.AppendFormat(".{0}", N1QlHelpers.EscapeIdentifier(memberName));
+                }
+            }
+
+            return expression;
+        }
+
+        protected override Expression VisitUnary(UnaryExpression expression)
+        {
+            switch (expression.NodeType)
+            {
+                case ExpressionType.Not:
+                    _expression.Append("NOT ");
+                    Visit(expression.Operand);
+                    break;
+
+                case ExpressionType.Negate:
+                case ExpressionType.NegateChecked:
+                    _expression.Append('-');
+                    Visit(expression.Operand);
+                    break;
+
+                default:
+                    Visit(expression.Operand);
+                    break;
+            }
+            return expression;
+        }
+
+        protected override Expression VisitSubQuery(SubQueryExpression expression)
+        {
+            var modelVisitor = new N1QlQueryModelVisitor(QueryGenerationContext, true);
+
+            modelVisitor.VisitQueryModel(expression.QueryModel);
+            _expression.Append(modelVisitor.GetQuery());
+
+            return expression;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/N1QLLetQueryPart.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/N1QLLetQueryPart.cs
@@ -1,0 +1,18 @@
+﻿namespace Couchbase.EntityFramework.QueryGeneration
+{
+    /// <summary>
+    /// Represents an item in the LET part of a N1QL query
+    /// </summary>
+    internal class N1QlLetQueryPart
+    {
+        /// <summary>
+        /// Name of the value being assigned
+        /// </summary>
+        public string ItemName { get; set; }
+
+        /// <summary>
+        /// Expression assigned to the item name
+        /// </summary>
+        public string Value { get; set; }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/N1QLQueryModelVisitor.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/N1QLQueryModelVisitor.cs
@@ -1,0 +1,1491 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.Core.Serialization;
+using Couchbase.EntityFramework.Clauses;
+using Couchbase.EntityFramework.Execution;
+using Couchbase.EntityFramework.Operators;
+using Couchbase.EntityFramework.QueryGeneration.ExpressionTransformers;
+using Couchbase.EntityFramework.QueryGeneration.FromParts;
+using Couchbase.EntityFramework.QueryGeneration.MemberNameResolvers;
+using Couchbase.EntityFramework.Versioning;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ResultOperators;
+using Remotion.Linq.Parsing.ExpressionVisitors;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
+
+namespace Couchbase.EntityFramework.QueryGeneration
+{
+    internal class N1QlQueryModelVisitor : QueryModelVisitorBase, IN1QlQueryModelVisitor
+    {
+        #region Constants
+
+        private enum VisitStatus
+        {
+            None,
+
+            // Group subqueries are used when clauses are applied after a group operation, such as .Where clauses
+            // which are treated as HAVING statements.
+            InGroupSubquery,
+            AfterGroupSubquery,
+
+            // Union sort subquerys are used if .OrderBy clauses are applied after performing a union
+            // The require special handling because the sorting is now on the generic name of the columns being returned
+            // Not on the original column names
+            InUnionSortSubquery,
+            AfterUnionSortSubquery
+        }
+
+        #endregion
+
+        private readonly N1QlQueryGenerationContext _queryGenerationContext;
+        private readonly QueryPartsAggregator _queryPartsAggregator = new QueryPartsAggregator();
+        private readonly List<UnclaimedGroupJoin> _unclaimedGroupJoins = new List<UnclaimedGroupJoin>();
+        private readonly ScalarResultBehavior _scalarResultBehavior = new ScalarResultBehavior();
+
+        private readonly bool _isSubQuery = false;
+
+        /// <summary>
+        /// Indicates if an aggregate has been applied, which may change select clause handling
+        /// </summary>
+        private bool _isAggregated = false;
+
+        /// <summary>
+        /// Tracks special status related to the visiting process, which may alter the behavior as query model
+        /// clauses are being visited.  For example, .Where clauses are treating as HAVING statements if
+        /// _visitStatus == AfterGroupSubquery.
+        /// </summary>
+        private VisitStatus _visitStatus = VisitStatus.None;
+
+        /// <summary>
+        /// Stores the mappings between expressions outside the group query to the extents inside
+        /// </summary>
+        private ExpressionTransformerRegistry _groupingExpressionTransformerRegistry;
+
+        /// <summary>
+        /// Provides information about how scalar results should be extracted from the N1QL query result after execution.
+        /// </summary>
+        public ScalarResultBehavior ScalarResultBehavior
+        {
+            get { return _scalarResultBehavior; }
+        }
+
+        private bool CanUseRawSelection => _queryGenerationContext.ClusterVersion >= FeatureVersions.SelectRaw;
+
+        public N1QlQueryModelVisitor(IMemberNameResolver memberNameResolver, IMethodCallTranslatorProvider methodCallTranslatorProvider,
+            ITypeSerializer serializer)
+        {
+            _queryGenerationContext = new N1QlQueryGenerationContext()
+            {
+                //MemberNameResolver = new JsonNetMemberNameResolver(ClusterHelper.Get().Configuration.SerializationSettings.ContractResolver),
+                //MethodCallTranslatorProvider = new DefaultMethodCallTranslatorProvider()
+                MemberNameResolver = memberNameResolver,
+                MethodCallTranslatorProvider = methodCallTranslatorProvider,
+                Serializer = serializer
+            };
+        }
+
+        public N1QlQueryModelVisitor(N1QlQueryGenerationContext queryGenerationContext) : this(queryGenerationContext, false)
+        {
+        }
+
+        /// <exception cref="ArgumentNullException"><paramref name="queryGenerationContext"/> is <see langword="null" />.</exception>
+        public N1QlQueryModelVisitor(N1QlQueryGenerationContext queryGenerationContext, bool isSubQuery)
+        {
+            if (queryGenerationContext == null)
+            {
+                throw new ArgumentNullException("queryGenerationContext");
+            }
+
+            _queryGenerationContext = queryGenerationContext;
+            _isSubQuery = isSubQuery;
+
+            if (isSubQuery)
+            {
+                _queryPartsAggregator.QueryType = N1QlQueryType.Subquery;
+            }
+        }
+
+        public string GetQuery()
+        {
+            return _queryPartsAggregator.BuildN1QlQuery();
+        }
+
+        /// <exception cref="NotSupportedException">N1QL Requires All Group Joins Have A Matching From Clause Subquery</exception>
+        public override void VisitQueryModel(QueryModel queryModel)
+        {
+            queryModel.MainFromClause.Accept(this, queryModel);
+            VisitBodyClauses(queryModel.BodyClauses, queryModel);
+
+            if (_unclaimedGroupJoins.Any())
+            {
+                if (_queryGenerationContext.ClusterVersion < FeatureVersions.IndexJoin)
+                {
+                    throw new NotSupportedException("N1QL Requires All Group Joins Have A Matching From Clause Subquery");
+                }
+
+                // See if any of the unclaimed group joins are really NEST operations
+
+                foreach (var join in _unclaimedGroupJoins)
+                {
+                    var fromQueryPart = ParseNestJoinClause(join.JoinClause, join.GroupJoinClause);
+                    _queryPartsAggregator.AddExtent(fromQueryPart);
+                }
+            }
+
+            VisitResultOperators(queryModel.ResultOperators, queryModel);
+
+            if ((_visitStatus != VisitStatus.InGroupSubquery) && (_visitStatus != VisitStatus.AfterUnionSortSubquery))
+            {
+                // Select clause should not be visited for grouping subqueries or for the outer query when sorting unions
+
+                // Select clause must be visited after the from clause and body clauses
+                // This ensures that any extents are linked before being referenced in the select statement
+                // Select clause must be visited after result operations because Any and All operators
+                // May change how we handle the select clause
+
+                queryModel.SelectClause.Accept(this, queryModel);
+            }
+
+            if (!string.IsNullOrEmpty(_queryPartsAggregator.ExplainPart))
+            {
+                // We no longer need to extract the result, because now the query is returning an explanation instead
+
+                ScalarResultBehavior.ResultExtractionRequired = false;
+            }
+        }
+
+        /// <exception cref="NotSupportedException">N1Ql Bucket Subqueries Require A UseKeys Call</exception>
+        public override void VisitMainFromClause(MainFromClause fromClause, QueryModel queryModel)
+        {
+            if (fromClause.ItemName.StartsWith(ExtentNameExpressionNode.ItemNamePrefix))
+            {
+                // There is a hardcoded value for the extent name to be used, so use this value instead
+                // of automatically generating a value.
+
+                _queryGenerationContext.ExtentNameProvider.SetExtentName(fromClause,
+                    fromClause.ItemName.Substring(ExtentNameExpressionNode.ItemNamePrefix.Length));
+            }
+
+            var bucketConstantExpression = fromClause.FromExpression as ConstantExpression;
+            if ((bucketConstantExpression != null) &&
+                typeof(IBucketQueryable).GetTypeInfo().IsAssignableFrom(bucketConstantExpression.Type))
+            {
+                if (_isSubQuery && !queryModel.BodyClauses.Any(p => p is UseKeysClause))
+                {
+                    throw new NotSupportedException("N1Ql Bucket Subqueries Require A UseKeys Call");
+                }
+
+                _queryPartsAggregator.AddExtent(new FromPart(fromClause)
+                {
+                    Source = N1QlHelpers.EscapeIdentifier(((IBucketQueryable) bucketConstantExpression.Value).BucketName),
+                    ItemName = GetExtentName(fromClause)
+                });
+            }
+            else if (fromClause.FromExpression.NodeType == ExpressionType.MemberAccess)
+            {
+                if (!_isSubQuery)
+                {
+                    throw new NotSupportedException("Member Access In The Main From Clause Is Only Supported In Subqueries");
+                }
+
+                _queryPartsAggregator.AddExtent(new FromPart(fromClause)
+                {
+                    Source = GetN1QlExpression((MemberExpression) fromClause.FromExpression),
+                    ItemName = GetExtentName(fromClause)
+                });
+
+                // This is an Array type subquery, since we're querying against a member not a bucket
+                _queryPartsAggregator.QueryType = N1QlQueryType.Array;
+            }
+            else if (fromClause.FromExpression is SubQueryExpression)
+            {
+                VisitSubQueryFromClause(fromClause, (SubQueryExpression) fromClause.FromExpression);
+            }
+            else if (fromClause.FromExpression is QuerySourceReferenceExpression querySourceReferenceExpression)
+            {
+                if (querySourceReferenceExpression.ReferencedQuerySource is GroupJoinClause)
+                {
+                    // This is an array subquery against a NEST clause
+                    VisitArrayFromClause(fromClause);
+                }
+                else if (fromClause.FromExpression.Equals(_queryGenerationContext.GroupingQuerySource))
+                {
+                    // We're performing an aggregate against a group
+                    _queryPartsAggregator.QueryType = N1QlQueryType.Aggregate;
+
+                    // Ensure that we use the same extent name as the grouping
+                    _queryGenerationContext.ExtentNameProvider.LinkExtents(
+                        _queryGenerationContext.GroupingQuerySource.ReferencedQuerySource, fromClause);
+                }
+                else
+                {
+                    throw new NotSupportedException("From Clause Is Referencing An Invalid Query Source");
+                }
+            }
+            else if (fromClause.FromExpression is ConstantExpression)
+            {
+                // From clause for this subquery is a constant array
+
+                VisitArrayFromClause(fromClause);
+            }
+
+            base.VisitMainFromClause(fromClause, queryModel);
+        }
+
+        private void VisitArrayFromClause(MainFromClause fromClause)
+        {
+            _queryPartsAggregator.QueryType = N1QlQueryType.Array;
+
+            _queryPartsAggregator.AddExtent(new FromPart(fromClause)
+            {
+                Source = GetN1QlExpression(fromClause.FromExpression),
+                ItemName = GetExtentName(fromClause)
+            });
+        }
+
+        private void VisitSubQueryFromClause(MainFromClause fromClause, SubQueryExpression subQuery)
+        {
+            if (subQuery.QueryModel.ResultOperators.Any(p => p is GroupResultOperator))
+            {
+                // We're applying functions like HAVING clauses after grouping
+
+                _visitStatus = VisitStatus.InGroupSubquery;
+                _queryGenerationContext.GroupingQuerySource = new QuerySourceReferenceExpression(fromClause);
+
+                VisitQueryModel(subQuery.QueryModel);
+
+                _visitStatus = VisitStatus.AfterGroupSubquery;
+            }
+            else if (subQuery.QueryModel.ResultOperators.Any(p => p is UnionResultOperator || p is ConcatResultOperator))
+            {
+                // We're applying ORDER BY clauses after a UNION statement is completed
+
+                _visitStatus = VisitStatus.InUnionSortSubquery;
+
+                VisitQueryModel(subQuery.QueryModel);
+
+                _visitStatus = VisitStatus.AfterUnionSortSubquery;
+
+                // When visiting the order by clauses after a union, member references shouldn't include extent names.
+                // Instead, they should reference the name of the columns without an extent qualifier.
+                _queryGenerationContext.ExtentNameProvider.SetBlankExtentName(fromClause);
+            }
+            else
+            {
+                throw new NotSupportedException("Subqueries In The Main From Clause Are Only Supported For Grouping And Unions");
+            }
+        }
+
+        public virtual void VisitUseKeysClause(UseKeysClause clause, QueryModel queryModel, int index)
+        {
+            _queryPartsAggregator.AddUseKeysPart(GetN1QlExpression(clause.Keys));
+        }
+
+        public virtual void VisitHintClause(HintClause clause, QueryModel queryModel, int index)
+        {
+            VisitHintClause(clause, _queryPartsAggregator.Extents[0]);
+        }
+
+        public virtual void VisitHintClause(HintClause clause, ExtentPart fromPart)
+        {
+            if (fromPart.Hints == null)
+            {
+                fromPart.Hints = new List<HintClause>();
+            }
+            else if (fromPart.Hints.Any(p => p.GetType() == clause.GetType()))
+            {
+                throw new NotSupportedException($"Only one {clause.GetType().Name} is allowed per extent.");
+            }
+
+            if (clause is UseHashClause)
+            {
+                if (_queryGenerationContext.ClusterVersion < FeatureVersions.AnsiJoin)
+                {
+                    throw new NotSupportedException($"Hash joins are not supported before Couchbase Server {FeatureVersions.AnsiJoin}");
+                }
+
+                if (!(fromPart is AnsiJoinPart))
+                {
+                    throw new NotSupportedException("UseHash is only supported on joined extents");
+                }
+            }
+
+            fromPart.Hints.Add(clause);
+        }
+
+        public override void VisitSelectClause(SelectClause selectClause, QueryModel queryModel)
+        {
+            if (_queryPartsAggregator.QueryType == N1QlQueryType.SubqueryAny)
+            {
+                // For Any type subqueries, the select statement is unused
+                // So just put a *
+
+                _queryPartsAggregator.SelectPart = "*";
+            }
+            else if (_queryPartsAggregator.QueryType == N1QlQueryType.SubqueryAll)
+            {
+                // For All type subqueries, the select statement should just provide all extents
+                // So they can be referenced by the SATISFIES statement
+                // Select statement that was defined originally is unused
+
+                _queryPartsAggregator.SelectPart = GetExtentSelectParameters();
+            }
+            else
+            {
+                _queryPartsAggregator.SelectPart = GetSelectParameters(selectClause, queryModel);
+
+                base.VisitSelectClause(selectClause, queryModel);
+            }
+        }
+
+        /// <summary>
+        /// Builds select clause when we're directly referencing elements of a query extent.
+        /// Could represent an array of documents or an array subdocument.
+        /// </summary>
+        private string GetQuerySourceSelectParameters(SelectClause selectClause, QueryModel queryModel)
+        {
+            if (_isAggregated)
+            {
+                // for aggregates, just use "*" (i.e. AggregateFunction = "COUNT", expression = "*" results in COUNT(*)"
+
+                if (!CanUseRawSelection)
+                {
+                    ScalarResultBehavior.ResultExtractionRequired = true;
+                    _queryPartsAggregator.PropertyExtractionPart = N1QlHelpers.EscapeIdentifier("result");
+                }
+                else
+                {
+                    _queryPartsAggregator.RawSelection = true;
+                }
+
+                return "*";
+            }
+
+            if (_queryPartsAggregator.IsArraySubquery)
+            {
+                // For unaggregated array subqueries, just select the array element directly
+                // i.e. ARRAY p FOR p IN someArray WHEN p.x = 1 END
+                // The select clause being the first "p" in the ARRAY
+
+                return GetN1QlExpression(selectClause.Selector);
+            }
+
+            if (!CanUseRawSelection)
+            {
+                if (IsScalarType(selectClause.Selector.Type))
+                {
+                    // We unnested an array of scalars
+                    // So don't apply .*, instead extract the scalars as a `result` property on the object
+                    // i.e. SELECT Extent2 as result FROM bucket as Extent1 UNNEST Extent1.array as Extent2
+
+                    ScalarResultBehavior.ResultExtractionRequired = true;
+                    _queryPartsAggregator.PropertyExtractionPart = N1QlHelpers.EscapeIdentifier("result");
+
+                    return GetN1QlExpression(selectClause.Selector);
+                }
+
+                // This is a simple object selection, so give us all of the properties of the object
+                // i.e. SELECT Extent1.* FROM bucket as Extent1
+
+                return string.Concat(GetN1QlExpression(selectClause.Selector), ".*",
+                    SelectDocumentMetadataIfRequired(queryModel));
+            }
+
+            if (_queryGenerationContext.SelectDocumentMetadata &&
+                _queryPartsAggregator.QueryType == N1QlQueryType.Select)
+            {
+                // We will also be selecting document metadata, so we can't use SELECT RAW
+
+                return string.Concat(GetN1QlExpression(selectClause.Selector), ".*",
+                    SelectDocumentMetadataIfRequired(queryModel));
+            }
+
+            // We can use SELECT RAW to get the result
+            _queryPartsAggregator.RawSelection = true;
+            return GetN1QlExpression(selectClause.Selector);
+        }
+
+        private string GetSelectParameters(SelectClause selectClause, QueryModel queryModel)
+        {
+            string expression;
+
+            if (selectClause.Selector is QuerySourceReferenceExpression)
+            {
+                expression = GetQuerySourceSelectParameters(selectClause, queryModel);
+            }
+            else if ((selectClause.Selector.NodeType == ExpressionType.New) || (selectClause.Selector.NodeType == ExpressionType.MemberInit))
+            {
+                if (_queryPartsAggregator.QueryType != N1QlQueryType.Array)
+                {
+                    var selector = selectClause.Selector;
+
+                    if (_visitStatus == VisitStatus.AfterGroupSubquery)
+                    {
+                        // SELECT clauses must be remapped to refer directly to the extents in the grouping subquery
+                        // rather than refering to the output of the grouping subquery
+
+                        selector = TransformingExpressionVisitor.Transform(selector, _groupingExpressionTransformerRegistry);
+                    }
+
+                    if (!_isAggregated)
+                    {
+                        expression = N1QlExpressionTreeVisitor.GetN1QlSelectNewExpression(selector,
+                            _queryGenerationContext);
+                    }
+                    else
+                    {
+                        if (!CanUseRawSelection)
+                        {
+                            ScalarResultBehavior.ResultExtractionRequired = true;
+                            _queryPartsAggregator.PropertyExtractionPart = N1QlHelpers.EscapeIdentifier("result");
+                        }
+                        else
+                        {
+                            _queryPartsAggregator.RawSelection = true;
+                        }
+
+                        // Don't use special "x as y" syntax inside an aggregate function, just make a new object with {y: x}
+                        expression = GetN1QlExpression(selectClause.Selector);
+                    }
+                }
+                else
+                {
+                    expression = GetN1QlExpression(selectClause.Selector);
+                }
+            }
+            else
+            {
+                expression = GetN1QlExpression(selectClause.Selector);
+
+                if (!CanUseRawSelection)
+                {
+                    if (_queryPartsAggregator.QueryType == N1QlQueryType.Subquery)
+                    {
+                        // For LINQ, this subquery is expected to return a list of the specific property being selected
+                        // But N1QL will always return a list of objects with a single property
+                        // So we need to use an ARRAY statement to convert the list
+
+                        _queryPartsAggregator.PropertyExtractionPart = N1QlHelpers.EscapeIdentifier("result");
+
+                        expression += " as " + _queryPartsAggregator.PropertyExtractionPart;
+                    }
+                    else
+                    {
+                        // This is a select expression on the main query that doesn't use a "new" clause, and isn't against an extent
+                        // So it will return an array of objects with properties, while LINQ is expecting an array of values
+                        // Since we can't extract the properties from the object in N1QL like we can with subqueries
+                        // We need to indicate to the BucketQueryExecutor that it will need to extract the properties
+
+                        _queryPartsAggregator.PropertyExtractionPart = N1QlHelpers.EscapeIdentifier("result");
+                        ScalarResultBehavior.ResultExtractionRequired = true;
+                    }
+                }
+                else if (_queryPartsAggregator.QueryType != N1QlQueryType.Aggregate)
+                {
+                    _queryPartsAggregator.RawSelection = true;
+                }
+            }
+
+            return expression;
+        }
+
+        /// <summary>
+        /// Provide a SELECT clause to returns all extents from the query
+        /// </summary>
+        /// <returns></returns>
+        private string GetExtentSelectParameters()
+        {
+            IEnumerable<string> extents = _queryPartsAggregator.Extents.Select(p => p.ItemName);
+
+            if (_queryPartsAggregator.LetParts != null)
+            {
+                extents = extents.Concat(_queryPartsAggregator.LetParts.Select(p => p.ItemName));
+            }
+            return string.Join(", ", extents);
+        }
+
+        /// <summary>
+        /// Provides the string to append to the SELECT list if we need to select the document metadata.
+        /// Otherwise returns an empty string.
+        /// </summary>
+        /// <param name="queryModel">Query model being visited.  Used to extract the MainFromClause.</param>
+        private string SelectDocumentMetadataIfRequired(QueryModel queryModel)
+        {
+            if (_queryGenerationContext.SelectDocumentMetadata && (_queryPartsAggregator.QueryType == N1QlQueryType.Select))
+            {
+                // The query generator must be requesting the document metadata
+                // And this must be the main query, not a sub query
+
+                return string.Format(", META({0}) as `__metadata`",
+                    GetN1QlExpression(new QuerySourceReferenceExpression(queryModel.MainFromClause)));
+            }
+            else
+            {
+                return "";
+            }
+        }
+
+        public override void VisitWhereClause(WhereClause whereClause, QueryModel queryModel, int index)
+        {
+            if (_visitStatus != VisitStatus.AfterGroupSubquery)
+            {
+                var predicate = whereClause.Predicate;
+
+                if (_queryPartsAggregator.Extents.Count > 1)
+                {
+                    // There is more than one extent, so one may be an INNER NEST
+                    var innerNestDetectingVistor = new InnerNestDetectingExpressionVisitor(_queryPartsAggregator);
+                    predicate = innerNestDetectingVistor.Visit(predicate);
+                }
+
+                _queryPartsAggregator.AddWherePart(GetN1QlExpression(predicate));
+            }
+            else
+            {
+                _queryPartsAggregator.AddHavingPart(GetN1QlExpression(whereClause.Predicate));
+            }
+
+            base.VisitWhereClause(whereClause, queryModel, index);
+        }
+
+        public override void VisitResultOperator(ResultOperatorBase resultOperator, QueryModel queryModel, int index)
+        {
+            if ((resultOperator is TakeResultOperator))
+            {
+                var takeResultOperator = resultOperator as TakeResultOperator;
+
+                _queryPartsAggregator.AddLimitPart(" LIMIT {0}",
+                    Convert.ToInt32(GetN1QlExpression(takeResultOperator.Count)));
+            }
+            else if (resultOperator is SkipResultOperator)
+            {
+                var skipResultOperator = resultOperator as SkipResultOperator;
+
+                _queryPartsAggregator.AddOffsetPart(" OFFSET {0}",
+                    Convert.ToInt32(GetN1QlExpression(skipResultOperator.Count)));
+            }
+            else if (resultOperator is FirstResultOperator)
+            {
+                // We can save query execution time with a short circuit for .First()
+
+                _queryPartsAggregator.AddLimitPart(" LIMIT {0}", 1);
+            }
+            else if (resultOperator is SingleResultOperator)
+            {
+                // We can save query execution time with a short circuit for .Single()
+                // But we have to get at least 2 results so we know if there was more than 1
+
+                _queryPartsAggregator.AddLimitPart(" LIMIT {0}", 2);
+            }
+            else if (resultOperator is DistinctResultOperator)
+            {
+                var distinctResultOperator = resultOperator as DistinctResultOperator;
+                _queryPartsAggregator.AddDistinctPart("DISTINCT ");
+            }
+            else if (resultOperator is ExplainResultOperator)
+            {
+                _queryPartsAggregator.ExplainPart = "EXPLAIN ";
+            }
+            else if (resultOperator is ToQueryRequestResultOperator)
+            {
+                // Do nothing, conversion will be handled by BucketQueryExecutor
+            }
+            else if (resultOperator is AnyResultOperator)
+            {
+                _queryPartsAggregator.QueryType =
+                    _queryPartsAggregator.QueryType == N1QlQueryType.Array ? N1QlQueryType.ArrayAny :
+                        _queryPartsAggregator.QueryType == N1QlQueryType.Subquery ? N1QlQueryType.SubqueryAny : N1QlQueryType.MainQueryAny;
+
+                if (_queryPartsAggregator.QueryType == N1QlQueryType.SubqueryAny)
+                {
+                    // For any Any query this value won't be used
+                    // But we'll generate it for consistency
+
+                    _queryPartsAggregator.PropertyExtractionPart =
+                        _queryGenerationContext.ExtentNameProvider.GetUnlinkedExtentName();
+                }
+                else if (_queryPartsAggregator.QueryType == N1QlQueryType.MainQueryAny)
+                {
+                    // Result must be extracted from the result attribute on the returned JSON document
+                    // If no rows are returned, for an Any operation we should return false.
+
+                    ScalarResultBehavior.ResultExtractionRequired = true;
+                    ScalarResultBehavior.NoRowsResult = false;
+                }
+            }
+            else if (resultOperator is AllResultOperator)
+            {
+                _queryPartsAggregator.QueryType =
+                    _queryPartsAggregator.QueryType == N1QlQueryType.Array ? N1QlQueryType.ArrayAll :
+                        _queryPartsAggregator.QueryType == N1QlQueryType.Subquery ? N1QlQueryType.SubqueryAll : N1QlQueryType.MainQueryAll;
+
+                bool prefixedExtents = false;
+                if (_queryPartsAggregator.QueryType == N1QlQueryType.SubqueryAll)
+                {
+                    // We're putting allResultOperator.Predicate in the SATISFIES clause of an ALL clause
+                    // Each extent of the subquery will be a property returned by the subquery
+                    // So we need to prefix the references to the subquery in the predicate with the iterator name from the ALL clause
+
+                    _queryPartsAggregator.PropertyExtractionPart =
+                        _queryGenerationContext.ExtentNameProvider.GetUnlinkedExtentName();
+
+                    prefixedExtents = true;
+                    _queryGenerationContext.ExtentNameProvider.Prefix = _queryPartsAggregator.PropertyExtractionPart + ".";
+                }
+                else if (_queryPartsAggregator.QueryType == N1QlQueryType.ArrayAll)
+                {
+                    // We're dealing with an array-type subquery
+                    // If there is any pre-filtering on the array using a Where clause, these statements will be
+                    // referencing the query source using the default extent name.  When we apply the SATISFIES clause
+                    // we'll need to use a new extent name to reference the results of the internal WHERE clause.
+
+                    _queryPartsAggregator.PropertyExtractionPart =
+                        _queryGenerationContext.ExtentNameProvider.GenerateNewExtentName(queryModel.MainFromClause);
+                }
+                else if (_queryPartsAggregator.QueryType == N1QlQueryType.MainQueryAll)
+                {
+                    // Result must be extracted from the result attribute on the returned JSON document
+                    // If no rows are returned, for an All operation we should return true.
+
+                    ScalarResultBehavior.ResultExtractionRequired = true;
+                    ScalarResultBehavior.NoRowsResult = true;
+                }
+
+                var allResultOperator = (AllResultOperator) resultOperator;
+                _queryPartsAggregator.WhereAllPart = GetN1QlExpression(allResultOperator.Predicate);
+
+                if (prefixedExtents)
+                {
+                    _queryGenerationContext.ExtentNameProvider.Prefix = null;
+                }
+            }
+            else if (resultOperator is ContainsResultOperator)
+            {
+                if (_queryPartsAggregator.QueryType != N1QlQueryType.Array)
+                {
+                    throw new NotSupportedException("Contains is only supported in N1QL against nested or constant arrays.");
+                }
+
+                var containsResultOperator = (ContainsResultOperator) resultOperator;
+
+                // Use a wrapping function to wrap the subquery with an IN statement
+
+                _queryPartsAggregator.AddWrappingFunction(GetN1QlExpression(containsResultOperator.Item) + " IN ");
+            }
+            else if (resultOperator is GroupResultOperator)
+            {
+                VisitGroupResultOperator((GroupResultOperator)resultOperator, queryModel);
+            }
+            else if (resultOperator is AverageResultOperator)
+            {
+                _queryPartsAggregator.AggregateFunction = "AVG";
+                _isAggregated = true;
+            }
+            else if ((resultOperator is CountResultOperator) || (resultOperator is LongCountResultOperator))
+            {
+                _queryPartsAggregator.AggregateFunction = "COUNT";
+                _isAggregated = true;
+            }
+            else if (resultOperator is MaxResultOperator)
+            {
+                _queryPartsAggregator.AggregateFunction = "MAX";
+                _isAggregated = true;
+            }
+            else if (resultOperator is MinResultOperator)
+            {
+                _queryPartsAggregator.AggregateFunction = "MIN";
+                _isAggregated = true;
+            }
+            else if (resultOperator is SumResultOperator)
+            {
+                _queryPartsAggregator.AggregateFunction = "SUM";
+                _isAggregated = true;
+            }
+            else if (resultOperator is UnionResultOperator)
+            {
+                EnsureNotArraySubquery();
+
+                var source = ((UnionResultOperator) resultOperator).Source2 as SubQueryExpression;
+                if (source == null)
+                {
+                    throw new NotSupportedException("Union is only support against query sources.");
+                }
+
+                VisitUnion(source, true);
+            }
+            else if (resultOperator is ConcatResultOperator)
+            {
+                EnsureNotArraySubquery();
+
+                var source = ((ConcatResultOperator)resultOperator).Source2 as SubQueryExpression;
+                if (source == null)
+                {
+                    throw new NotSupportedException("Concat is only support against query sources.");
+                }
+
+                VisitUnion(source, false);
+            }
+            else
+            {
+                throw new NotSupportedException(string.Format("{0} is not supported.", resultOperator.GetType().Name));
+            }
+
+            base.VisitResultOperator(resultOperator, queryModel, index);
+        }
+
+        private void VisitUnion(SubQueryExpression source, bool distinct)
+        {
+            var queryModelVisitor = new N1QlQueryModelVisitor(_queryGenerationContext.CloneForUnion());
+
+            queryModelVisitor.VisitQueryModel(source.QueryModel);
+            var unionQuery = queryModelVisitor.GetQuery();
+
+            _queryPartsAggregator.AddUnionPart((distinct ? " UNION " : " UNION ALL ") + unionQuery);
+        }
+
+        #region Grouping
+
+        protected virtual void VisitGroupResultOperator(GroupResultOperator groupResultOperator, QueryModel queryModel)
+        {
+            _groupingExpressionTransformerRegistry = new ExpressionTransformerRegistry();
+
+            // Add GROUP BY clause for the grouping key
+            // And add transformations for any references to the key
+
+            if (groupResultOperator.KeySelector.NodeType == ExpressionType.New)
+            {
+                // Grouping by a multipart key, so add each key to the GROUP BY clause
+
+                var newExpression = (NewExpression) groupResultOperator.KeySelector;
+
+                foreach (var argument in newExpression.Arguments)                {
+                    _queryPartsAggregator.AddGroupByPart(GetN1QlExpression(argument));
+                }
+
+                // Use MultiKeyExpressionTransformer to remap access to the Key property
+
+                _groupingExpressionTransformerRegistry.Register(
+                    new MultiKeyExpressionTransfomer(_queryGenerationContext.GroupingQuerySource, newExpression));
+            }
+            else
+            {
+                // Grouping by a single column
+
+                _queryPartsAggregator.AddGroupByPart(GetN1QlExpression(groupResultOperator.KeySelector));
+
+                // Use KeyExpressionTransformer to remap access to the Key property
+
+                _groupingExpressionTransformerRegistry.Register(
+                    new KeyExpressionTransfomer(_queryGenerationContext.GroupingQuerySource, groupResultOperator.KeySelector));
+            }
+
+            // Add transformations for any references to the element selector
+
+            var querySource = groupResultOperator.ElementSelector as QuerySourceReferenceExpression;
+            if (querySource != null)
+            {
+                _queryGenerationContext.ExtentNameProvider.LinkExtents(
+                    querySource.ReferencedQuerySource,
+                    _queryGenerationContext.GroupingQuerySource.ReferencedQuerySource);
+            }
+            else
+            {
+                throw new NotSupportedException("Unsupported GroupResultOperator ElementSelector Type");
+            }
+        }
+
+        #endregion
+
+        #region Order By Clauses
+
+        public override void VisitOrderByClause(OrderByClause orderByClause, QueryModel queryModel, int index)
+        {
+            if (_visitStatus == VisitStatus.InGroupSubquery)
+            {
+                // Just ignore sorting before grouping takes place
+                return;
+            }
+
+            // Validate the status of array subqueries
+            if (_queryPartsAggregator.QueryType == N1QlQueryType.Array)
+            {
+                if (!VerifyArraySubqueryOrderByClause(orderByClause, queryModel, index))
+                {
+                    if (_queryGenerationContext.ClusterVersion < FeatureVersions.ArrayInFromClause)
+                    {
+                        throw new NotSupportedException(
+                            "N1QL Array Subqueries Support One Ordering By The Array Elements Only Prior To Server 5.0");
+                    }
+
+                    // Switch to an array subquery using SELECT ... FROM
+                    _queryPartsAggregator.QueryType = N1QlQueryType.Subquery;
+                }
+            }
+
+            if (_queryPartsAggregator.QueryType != N1QlQueryType.Array)
+            {
+                var orderByParts =
+                    orderByClause.Orderings.Select(
+                        ordering =>
+                            string.Concat(GetN1QlExpression(ordering.Expression), " ",
+                                ordering.OrderingDirection.ToString().ToUpper())).ToList();
+
+                _queryPartsAggregator.AddOrderByPart(orderByParts);
+
+                base.VisitOrderByClause(orderByClause, queryModel, index);
+            }
+            else
+            {
+                // This is an array subquery
+
+                _queryPartsAggregator.AddWrappingFunction("ARRAY_SORT");
+                if (orderByClause.Orderings[0].OrderingDirection == OrderingDirection.Desc)
+                {
+                    // There is no function to sort an array descending
+                    // so we just reverse the array after it's sorted ascending
+
+                    _queryPartsAggregator.AddWrappingFunction("ARRAY_REVERSE");
+                }
+            }
+        }
+
+        private bool VerifyArraySubqueryOrderByClause(OrderByClause orderByClause, QueryModel queryModel, int index)
+        {
+            // Arrays can only be sorted by a single ordering
+
+            if ((index > 0) || (orderByClause.Orderings.Count() != 1))
+            {
+                return false;
+            }
+
+            // Array must be ordered by the main from expression
+            // Which means the array elements themselves
+
+            var querySourceReferenceExpression = orderByClause.Orderings[0].Expression as QuerySourceReferenceExpression;
+            if (querySourceReferenceExpression == null)
+            {
+                return false;
+            }
+
+            var referencedQuerySource = querySourceReferenceExpression.ReferencedQuerySource as FromClauseBase;
+            if (referencedQuerySource == null)
+            {
+                return false;
+            }
+
+            if (referencedQuerySource.FromExpression != queryModel.MainFromClause.FromExpression)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        #endregion
+
+        #region Additional From Clauses
+
+        public override void VisitAdditionalFromClause(AdditionalFromClause fromClause, QueryModel queryModel, int index)
+        {
+            EnsureNotArraySubquery();
+
+            var handled = false;
+
+            if (fromClause.FromExpression.NodeType == ExpressionType.MemberAccess)
+            {
+                // Unnest operation
+
+                var fromPart = VisitMemberFromExpression(fromClause, fromClause.FromExpression as MemberExpression);
+                _queryPartsAggregator.AddExtent(fromPart);
+                handled = true;
+            }
+            else if (fromClause.FromExpression is SubQueryExpression)
+            {
+                // Might be an unnest or a join to another bucket
+
+                handled = VisitSubQueryFromExpression(fromClause, (SubQueryExpression) fromClause.FromExpression);
+            }
+
+            if (!handled)
+            {
+                throw new NotSupportedException("N1QL Does Not Support This Type Of From Clause");
+            }
+
+            base.VisitAdditionalFromClause(fromClause, queryModel, index);
+        }
+
+        /// <summary>
+        /// Visits an AdditionalFromClause that is executing a subquery
+        /// </summary>
+        /// <param name="fromClause">AdditionalFromClause being visited</param>
+        /// <param name="subQuery">Subquery being executed by the AdditionalFromClause</param>
+        /// <returns>True if handled</returns>
+        private bool VisitSubQueryFromExpression(AdditionalFromClause fromClause, SubQueryExpression subQuery)
+        {
+            var mainFromExpression = subQuery.QueryModel.MainFromClause.FromExpression;
+
+            if (mainFromExpression is QuerySourceReferenceExpression)
+            {
+                // Joining to another bucket using a previous group join operation
+
+                return VisitSubQuerySourceReferenceExpression(fromClause, subQuery,
+                    (QuerySourceReferenceExpression) mainFromExpression);
+            }
+            else if (mainFromExpression.NodeType == ExpressionType.MemberAccess)
+            {
+                // Unnest operation
+
+                var fromPart = VisitMemberFromExpression(fromClause, mainFromExpression as MemberExpression);
+
+                if (subQuery.QueryModel.ResultOperators.OfType<DefaultIfEmptyResultOperator>().Any())
+                {
+                    fromPart.JoinType = JoinTypes.LeftUnnest;
+                }
+
+                _queryPartsAggregator.AddExtent(fromPart);
+
+                // be sure the subquery clauses use the same extent name
+                _queryGenerationContext.ExtentNameProvider.LinkExtents(fromClause, subQuery.QueryModel.MainFromClause);
+
+                // Apply where filters in the subquery to the main query
+                VisitBodyClauses(subQuery.QueryModel.BodyClauses, subQuery.QueryModel);
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Visit an AdditionalFromClause referencing a previous group join clause
+        /// </summary>
+        /// <param name="fromClause">AdditionalFromClause being visited</param>
+        /// <param name="subQuery">SubQueryExpression being visited</param>
+        /// <param name="querySourceReference">QuerySourceReferenceExpression that is the MainFromClause of the SubQuery</param>
+        /// <returns>True if the additional from clause is valid.</returns>
+        private bool VisitSubQuerySourceReferenceExpression(AdditionalFromClause fromClause, SubQueryExpression subQuery,
+            QuerySourceReferenceExpression querySourceReference)
+        {
+            var unclaimedJoin =
+                    _unclaimedGroupJoins.FirstOrDefault(
+                        p => p.GroupJoinClause == querySourceReference.ReferencedQuerySource);
+            if (unclaimedJoin != null)
+            {
+                // this additional from clause is for a previous group join
+                // that was unclaimed as part of the pre-ANSI join style of query generation
+
+                var fromPart = ParseJoinClause(unclaimedJoin.JoinClause);
+
+                if (subQuery.QueryModel.ResultOperators.OfType<DefaultIfEmptyResultOperator>().Any())
+                {
+                    fromPart.JoinType = JoinTypes.LeftJoin;
+                }
+
+                // Be sure that any reference to the subquery gets the join clause extent name
+                _queryGenerationContext.ExtentNameProvider.LinkExtents(unclaimedJoin.JoinClause, fromClause);
+
+                _unclaimedGroupJoins.Remove(unclaimedJoin);
+                _queryPartsAggregator.AddExtent(fromPart);
+
+                return true;
+            }
+
+            var ansiNest = _queryPartsAggregator.Extents.OfType<AnsiJoinPart>()
+                .FirstOrDefault(p => p.QuerySource == querySourceReference.ReferencedQuerySource);
+            if (ansiNest != null)
+            {
+                // Convert the ANSI NEST to a JOIN because the additional from clause
+                // is flattening the query
+
+                ansiNest.JoinType = subQuery.QueryModel.ResultOperators.OfType<DefaultIfEmptyResultOperator>().Any()
+                    ? JoinTypes.LeftJoin
+                    : JoinTypes.InnerJoin;
+
+                // Be sure that any reference to the subquery gets the join clause extent name
+                _queryGenerationContext.ExtentNameProvider.LinkExtents(ansiNest.QuerySource, fromClause);
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Visit an AdditionalFromClause referencing a member
+        /// </summary>
+        /// <param name="fromClause">AdditionalFromClause being visited</param>
+        /// <param name="expression">MemberExpression being referenced</param>
+        /// <returns>N1QlFromQueryPart to be added to the QueryPartsAggregator.  JoinType is defaulted to INNER UNNEST.</returns>
+        private JoinPart VisitMemberFromExpression(AdditionalFromClause fromClause, MemberExpression expression)
+        {
+            // This case represents an unnest operation
+
+            return new JoinPart(fromClause)
+            {
+                Source = GetN1QlExpression(expression),
+                ItemName = GetExtentName(fromClause),
+                JoinType = JoinTypes.InnerUnnest
+            };
+        }
+
+        #endregion
+
+        #region Join Clauses
+
+        public override void VisitJoinClause(JoinClause joinClause, QueryModel queryModel,
+            GroupJoinClause groupJoinClause)
+        {
+            EnsureNotArraySubquery();
+
+            if (_queryGenerationContext.ClusterVersion < FeatureVersions.AnsiJoin)
+            {
+                // Store the group join with the expectation it will be used later by an additional from clause
+
+                _unclaimedGroupJoins.Add(new UnclaimedGroupJoin
+                {
+                    JoinClause = joinClause,
+                    GroupJoinClause = groupJoinClause
+                });
+            }
+            else
+            {
+                // Handle as an ANSI JOIN
+
+                var fromQueryPart = ParseNestJoinClause(joinClause, groupJoinClause);
+                _queryPartsAggregator.AddExtent(fromQueryPart);
+            }
+
+            base.VisitJoinClause(joinClause, queryModel, groupJoinClause);
+        }
+
+        public override void VisitJoinClause(JoinClause joinClause, QueryModel queryModel, int index)
+        {
+            // basic join clause is an INNER JOIN against another bucket
+
+            EnsureNotArraySubquery();
+
+            var fromQueryPart = ParseJoinClause(joinClause);
+
+            _queryPartsAggregator.AddExtent(fromQueryPart);
+
+            base.VisitJoinClause(joinClause, queryModel, index);
+        }
+
+        /// <summary>
+        /// Visits a join against either a constant expression of IBucketQueryable, or a subquery based on an IBucketQueryable
+        /// </summary>
+        /// <param name="joinClause">Join clause being visited</param>
+        /// <returns>N1QlFromQueryPart to be added to the QueryPartsAggregator.  JoinType is defaulted to INNER JOIN.</returns>
+        /// <remarks>The InnerKeySelector must be selecting the N1QlFunctions.Key of the InnerSequence</remarks>
+        private JoinPart ParseJoinClause(JoinClause joinClause)
+        {
+            if (joinClause.InnerSequence.NodeType == ExpressionType.Constant)
+            {
+                return VisitConstantExpressionJoinClause(joinClause, joinClause.InnerSequence as ConstantExpression);
+            }
+            else if (joinClause.InnerSequence is SubQueryExpression)
+            {
+                var subQuery = (SubQueryExpression) joinClause.InnerSequence;
+                if (subQuery.QueryModel.ResultOperators.Any() ||
+                    subQuery.QueryModel.MainFromClause.FromExpression.NodeType != ExpressionType.Constant)
+                {
+                    throw new NotSupportedException("Unsupported Join Inner Sequence");
+                }
+
+                // be sure the subquery clauses use the same name
+                _queryGenerationContext.ExtentNameProvider.LinkExtents(joinClause,
+                    subQuery.QueryModel.MainFromClause);
+
+                var fromPart = VisitConstantExpressionJoinClause(joinClause,
+                    subQuery.QueryModel.MainFromClause.FromExpression as ConstantExpression);
+
+                if (fromPart is AnsiJoinPart ansiJoinPart)
+                {
+                    // If the right hand extent is filtered the predicates must
+                    // be part of the ON statement rather than part of the general predicates.
+                    // However, we can only do this for ANSI joins.
+
+                    ansiJoinPart.AdditionalInnerPredicates = string.Join(" AND ",
+                        subQuery.QueryModel.BodyClauses
+                            .OfType<WhereClause>()
+                            .Select(p => GetN1QlExpression(p.Predicate)));
+
+                    foreach (var hintClause in subQuery.QueryModel.BodyClauses.OfType<HintClause>())
+                    {
+                        VisitHintClause(hintClause, fromPart);
+                    }
+                }
+                else
+                {
+                    if (subQuery.QueryModel.BodyClauses.Any(p => !(p is WhereClause)))
+                    {
+                        throw new NotSupportedException(
+                            "Only predicates are allowed on the right-hand extent of a join");
+                    }
+
+                    VisitBodyClauses(subQuery.QueryModel.BodyClauses, subQuery.QueryModel);
+                }
+
+                return fromPart;
+            }
+            else
+            {
+                throw new NotSupportedException("Unsupported Join Inner Sequence");
+            }
+        }
+
+        /// <summary>
+        /// Visits a join against a constant expression, which must be an IBucketQueryable implementation
+        /// </summary>
+        /// <param name="joinClause">Join clause being visited</param>
+        /// <param name="constantExpression">Constant expression that is the InnerSequence of the JoinClause</param>
+        /// <returns>N1QlFromQueryPart to be added to the QueryPartsAggregator.  JoinType is defaulted to INNER JOIN.</returns>
+        /// <remarks>The InnerKeySelector must be selecting the N1QlFunctions.Key of the InnerSequence</remarks>
+        private JoinPart VisitConstantExpressionJoinClause(JoinClause joinClause, ConstantExpression constantExpression)
+        {
+            string bucketName = null;
+
+            if (constantExpression != null)
+            {
+                if (constantExpression.Value is IBucketQueryable bucketQueryable)
+                {
+                    bucketName = bucketQueryable.BucketName;
+                }
+            }
+
+            if (bucketName == null)
+            {
+                throw new NotSupportedException("N1QL Joins Must Be Against IBucketQueryable");
+            }
+
+            if (_queryGenerationContext.ClusterVersion >= FeatureVersions.AnsiJoin)
+            {
+                // If ANSI joins are supported they are always preferred
+
+                return new AnsiJoinPart(joinClause)
+                {
+                    Source = N1QlHelpers.EscapeIdentifier(bucketName),
+                    ItemName = GetExtentName(joinClause),
+                    OuterKey = GetN1QlExpression(joinClause.OuterKeySelector),
+                    InnerKey = GetN1QlExpression(joinClause.InnerKeySelector),
+                    JoinType = JoinTypes.InnerJoin
+                };
+            }
+
+            if (IsKeyMethodCall(joinClause.InnerKeySelector, out var keyQuerySource))
+            {
+                // ON KEYS join
+                return new OnKeysJoinPart(joinClause)
+                {
+                    Source = N1QlHelpers.EscapeIdentifier(bucketName),
+                    ItemName = GetExtentName(joinClause),
+                    OnKeys = GetN1QlExpression(joinClause.OuterKeySelector),
+                    JoinType = JoinTypes.InnerJoin
+                };
+            }
+
+            if (_queryGenerationContext.ClusterVersion < FeatureVersions.IndexJoin)
+            {
+                throw new NotSupportedException(
+                    "N1QL Join Selector Must Be A Call To N1QlFunctions.Key Referencing The Inner Sequences");
+            }
+
+            if (!IsKeyMethodCall(joinClause.OuterKeySelector, out keyQuerySource))
+            {
+                throw new NotSupportedException(
+                    "N1QL Join Selector Must Be A Call To N1QlFunctions.Key Referencing One Of The Sequences");
+            }
+
+            // Index join
+            return new IndexJoinPart(joinClause)
+            {
+                Source = N1QlHelpers.EscapeIdentifier(bucketName),
+                ItemName = GetExtentName(joinClause),
+                OnKeys = GetN1QlExpression(joinClause.InnerKeySelector),
+                JoinType = JoinTypes.InnerJoin,
+                IndexJoinExtentName = GetExtentName(keyQuerySource)
+            };
+        }
+
+        #endregion
+
+        #region Nest Clause
+
+        public void VisitNestClause(NestClause nestClause, QueryModel queryModel, int index)
+        {
+            EnsureNotArraySubquery();
+
+            _queryPartsAggregator.AddExtent(ParseNestClause(nestClause));
+        }
+
+        /// <summary>
+        /// Visits a nest against either a constant expression of IBucketQueryable, or a subquery based on an IBucketQueryable
+        /// </summary>
+        /// <param name="nestClause">Nest clause being visited</param>
+        /// <returns>N1QlFromQueryPart to be added to the QueryPartsAggregator</returns>
+        private JoinPart ParseNestClause(NestClause nestClause)
+        {
+            if (nestClause.InnerSequence is ConstantExpression constantExpression)
+            {
+                return VisitConstantExpressionNestClause(nestClause, constantExpression, false);
+            }
+            else if (nestClause.InnerSequence is SubQueryExpression subQuery)
+            {
+                if (subQuery.QueryModel.ResultOperators.Any() ||
+                    subQuery.QueryModel.MainFromClause.FromExpression.NodeType != ExpressionType.Constant)
+                {
+                    throw new NotSupportedException("Unsupported Nest Inner Sequence");
+                }
+
+                var fromPart = VisitConstantExpressionNestClause(nestClause,
+                    subQuery.QueryModel.MainFromClause.FromExpression as ConstantExpression, true);
+
+                if (fromPart is AnsiJoinPart ansiJoinPart)
+                {
+                    // Ensure that the extents are linked before processing the where clause
+                    // So they have the same name
+                    _queryGenerationContext.ExtentNameProvider.LinkExtents(nestClause, subQuery.QueryModel.MainFromClause);
+
+                    ansiJoinPart.AdditionalInnerPredicates = string.Join(" AND ",
+                        subQuery.QueryModel.BodyClauses.OfType<WhereClause>()
+                            .Select(p => GetN1QlExpression(p.Predicate)));
+                }
+                else
+                {
+                    // Put any where clauses in the sub query in an ARRAY filtering clause using a LET statement
+
+                    var whereClauseString = string.Join(" AND ",
+                        subQuery.QueryModel.BodyClauses.OfType<WhereClause>()
+                            .Select(p => GetN1QlExpression(p.Predicate)));
+
+                    var letPart = new N1QlLetQueryPart()
+                    {
+                        ItemName = GetExtentName(nestClause),
+                        Value =
+                            string.Format("ARRAY {0} FOR {0} IN {1} WHEN {2} END",
+                                GetExtentName(subQuery.QueryModel.MainFromClause),
+                                fromPart.ItemName,
+                                whereClauseString)
+                    };
+
+                    _queryPartsAggregator.AddLetPart(letPart);
+
+                    if (!nestClause.IsLeftOuterNest)
+                    {
+                        // This is an INNER NEST, but the inner sequence filter is being applied after the NEST operation is done
+                        // So we need to put an additional filter to drop rows with an empty array result
+
+                        _queryPartsAggregator.AddWherePart("(ARRAY_LENGTH({0}) > 0)", letPart.ItemName);
+                    }
+                }
+
+                return fromPart;
+            }
+            else
+            {
+                throw new NotSupportedException("Unsupported Nest Inner Sequence");
+            }
+        }
+
+        /// <summary>
+        /// Visits a nest against a constant expression, which must be an IBucketQueryable implementation
+        /// </summary>
+        /// <param name="nestClause">Nest clause being visited</param>
+        /// <param name="constantExpression">Constant expression that is the InnerSequence of the NestClause</param>
+        /// <param name="isSubQuery">Indicates if this nest clause is a subquery which may require the use of a LET clause after the NEST</param>
+        /// <returns>N1QlFromQueryPart to be added to the QueryPartsAggregator</returns>
+        private JoinPart VisitConstantExpressionNestClause(NestClause nestClause, ConstantExpression constantExpression, bool isSubQuery)
+        {
+            string bucketName = null;
+
+            if (constantExpression != null)
+            {
+                var bucketQueryable = constantExpression.Value as IBucketQueryable;
+                if (bucketQueryable != null)
+                {
+                    bucketName = bucketQueryable.BucketName;
+                }
+            }
+
+            if (bucketName == null)
+            {
+                throw new NotSupportedException("N1QL Nests Must Be Against IBucketQueryable");
+            }
+
+            if (_queryGenerationContext.ClusterVersion < FeatureVersions.AnsiJoin)
+            {
+                return new OnKeysJoinPart(nestClause)
+                {
+                    Source = N1QlHelpers.EscapeIdentifier(bucketName),
+                    ItemName = isSubQuery
+                        // For subqueries, generate a temporary item name to use on the NEST statement, which we can then reference in the LET statement
+                        ? _queryGenerationContext.ExtentNameProvider.GetUnlinkedExtentName()
+                        : _queryGenerationContext.ExtentNameProvider.GetExtentName(nestClause),
+                    OnKeys = GetN1QlExpression(nestClause.KeySelector),
+                    JoinType = nestClause.IsLeftOuterNest ? JoinTypes.LeftNest : JoinTypes.InnerNest
+                };
+            }
+            else
+            {
+                var itemName = _queryGenerationContext.ExtentNameProvider.GetExtentName(nestClause);
+
+                return new AnsiJoinPart(nestClause)
+                {
+                    Source = N1QlHelpers.EscapeIdentifier(bucketName),
+                    ItemName = itemName,
+                    JoinType = nestClause.IsLeftOuterNest ? JoinTypes.LeftNest : JoinTypes.InnerNest,
+                    InnerKey = GetN1QlExpression(nestClause.KeySelector),
+                    OuterKey = $"META({itemName}).id",
+                    Operator = "IN"
+                };
+            }
+        }
+
+        /// <summary>
+        /// Visits an nest join against either a constant expression of IBucketQueryable, or a subquery based on an IBucketQueryable
+        /// </summary>
+        /// <param name="joinClause">Join clause being visited</param>
+        /// <param name="groupJoinClause">Group join clause being visited</param>
+        /// <returns>N1QlFromQueryPart to be added to the QueryPartsAggregator.  JoinType is defaulted to NEST.</returns>
+        /// <remarks>The OuterKeySelector must be selecting the N1QlFunctions.Key of the OuterSequence</remarks>
+        private JoinPart ParseNestJoinClause(JoinClause joinClause, GroupJoinClause groupJoinClause)
+        {
+            if (joinClause.InnerSequence.NodeType == ExpressionType.Constant)
+            {
+                var clause = VisitConstantExpressionJoinClause(joinClause, joinClause.InnerSequence as ConstantExpression);
+                clause.JoinType = JoinTypes.LeftNest;
+                clause.QuerySource = groupJoinClause;
+
+                _queryGenerationContext.ExtentNameProvider.LinkExtents(joinClause, groupJoinClause);
+
+                return clause;
+            }
+            else if (joinClause.InnerSequence is SubQueryExpression)
+            {
+                var subQuery = (SubQueryExpression)joinClause.InnerSequence;
+                if (subQuery.QueryModel.ResultOperators.Any() ||
+                    subQuery.QueryModel.MainFromClause.FromExpression.NodeType != ExpressionType.Constant)
+                {
+                    throw new NotSupportedException("Unsupported Join Inner Sequence");
+                }
+
+                // Generate a temporary item name to use on the NEST statement, which we can then reference in the LET statement
+
+                var fromPart = VisitConstantExpressionJoinClause(joinClause,
+                    subQuery.QueryModel.MainFromClause.FromExpression as ConstantExpression);
+                fromPart.JoinType = JoinTypes.LeftNest;
+                fromPart.QuerySource = groupJoinClause;
+
+                if (fromPart is AnsiJoinPart ansiJoinPart)
+                {
+                    // Ensure references to the join pass through to the group join
+                    _queryGenerationContext.ExtentNameProvider.LinkExtents(joinClause, groupJoinClause);
+                    _queryGenerationContext.ExtentNameProvider.LinkExtents(joinClause, subQuery.QueryModel.MainFromClause);
+
+                    // Put any where clauses in the sub query on the join
+                    ansiJoinPart.AdditionalInnerPredicates = string.Join(" AND ",
+                        subQuery.QueryModel.BodyClauses.OfType<WhereClause>()
+                            .Select(p => GetN1QlExpression(p.Predicate)));
+
+                    foreach (var hintClause in subQuery.QueryModel.BodyClauses.OfType<HintClause>())
+                    {
+                        VisitHintClause(hintClause, fromPart);
+                    }
+                }
+                else
+                {
+                    // Put any where clauses in the sub query in an ARRAY filtering clause using a LET statement
+
+                    var whereClauseString = string.Join(" AND ",
+                        subQuery.QueryModel.BodyClauses.OfType<WhereClause>()
+                            .Select(p => GetN1QlExpression(p.Predicate)));
+
+                    var letPart = new N1QlLetQueryPart()
+                    {
+                        ItemName = GetExtentName(groupJoinClause),
+                        Value =
+                            string.Format("ARRAY {0} FOR {0} IN {1} WHEN {2} END",
+                                GetExtentName(subQuery.QueryModel.MainFromClause),
+                                GetExtentName(joinClause),
+                                whereClauseString)
+                    };
+
+                    _queryPartsAggregator.AddLetPart(letPart);
+                }
+
+                return fromPart;
+            }
+            else
+            {
+                throw new NotSupportedException("Unsupported Join Inner Sequence");
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Determines if the expression is a valid call to <see cref="N1QlFunctions.Key"/>, with an
+        /// <see cref="IQuerySource"/> as the parameter.
+        /// </summary>
+        /// <param name="expression">Expression to evaluate.</param>
+        /// <param name="querySource">Returns the <see cref="IQuerySource"/> parameter for the call.</param>
+        /// <returns>True if the call is valid.</returns>
+        private static bool IsKeyMethodCall(Expression expression, out IQuerySource querySource)
+        {
+            querySource = null;
+
+            var keyExpression = expression as MethodCallExpression;
+            if ((keyExpression == null) ||
+                (keyExpression.Method != typeof(N1QlFunctions).GetMethod("Key")) ||
+                (keyExpression.Arguments.Count != 1))
+            {
+                return false;
+            }
+
+            var querySourceReference = keyExpression.Arguments[0] as QuerySourceReferenceExpression;
+            if (querySourceReference == null)
+            {
+                return false;
+            }
+
+            querySource = querySourceReference.ReferencedQuerySource;
+            return true;
+        }
+
+        private string GetN1QlExpression(Expression expression)
+        {
+            if (_visitStatus == VisitStatus.AfterGroupSubquery)
+            {
+                // SELECT, HAVING, and ORDER BY clauses must be remapped to refer directly to the extents in the grouping subquery
+                // rather than refering to the output of the grouping subquery
+
+                expression = TransformingExpressionVisitor.Transform(expression, _groupingExpressionTransformerRegistry);
+            }
+
+            return N1QlExpressionTreeVisitor.GetN1QlExpression(expression, _queryGenerationContext);
+        }
+
+        private string GetExtentName(IQuerySource querySource)
+        {
+            return _queryGenerationContext.ExtentNameProvider.GetExtentName(querySource);
+        }
+
+        private void EnsureNotArraySubquery()
+        {
+            if (_queryPartsAggregator.IsArraySubquery)
+            {
+                throw new NotSupportedException("N1QL Array Subqueries Do Not Support Joins, Nests, Union, Concat, Or Additional From Statements");
+            }
+        }
+
+        private static bool IsScalarType(Type type)
+        {
+            return type.GetTypeInfo().IsValueType || type == typeof(string);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/N1QLQueryType.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/N1QLQueryType.cs
@@ -1,0 +1,58 @@
+﻿namespace Couchbase.EntityFramework.QueryGeneration
+{
+    /// <summary>
+    /// Represents the type of query or subquery being generated
+    /// </summary>
+    internal enum N1QlQueryType
+    {
+        /// <summary>
+        /// Main SELECT statement
+        /// </summary>
+        Select = 0,
+
+        /// <summary>
+        /// Subquery against a bucket
+        /// </summary>
+        Subquery,
+
+        /// <summary>
+        /// Subquery against an array using the ARRAY keyword
+        /// </summary>
+        Array,
+
+        /// <summary>
+        /// Any operation performed on a nested array as a subquery
+        /// </summary>
+        ArrayAny,
+
+        /// <summary>
+        /// Any operation performed on a Couchbase bucket as the main query
+        /// </summary>
+        MainQueryAny,
+
+        /// <summary>
+        /// Any operation performed on a Couchbase bucket as a subquery
+        /// </summary>
+        SubqueryAny,
+
+        /// <summary>
+        /// All operation performed on a nested array as a subquery
+        /// </summary>
+        ArrayAll,
+
+        /// <summary>
+        /// All operation performed on a Couchbase bucket as the main query
+        /// </summary>
+        MainQueryAll,
+
+        /// <summary>
+        /// All operation performed on a Couchbase bucket as a subquery
+        /// </summary>
+        SubqueryAll,
+
+        /// <summary>
+        /// Represents a simple aggregate against a group.  Query returned will be the aggregate function call only.
+        /// </summary>
+        Aggregate
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/N1QlExtentNameProvider.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/N1QlExtentNameProvider.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using Remotion.Linq.Clauses;
+
+namespace Couchbase.EntityFramework.QueryGeneration
+{
+    /// <summary>
+    /// Provides unique names to use in N1QL queries for each IQuerySource extent
+    /// </summary>
+    internal class N1QlExtentNameProvider
+    {
+        private const string ExtentNameFormat = "Extent{0}";
+
+        private int _extentIndex = 0;
+        private readonly Dictionary<IQuerySource, string> _extentDictionary = new Dictionary<IQuerySource, string>();
+
+        /// <summary>
+        /// If non-null, prefixes all extent names.  I.e. If set to "`p`." then `Extent1` becomes `p`.`Extent1`
+        /// </summary>
+        public string Prefix { get; set; }
+
+        /// <summary>
+        /// Provides the extent name for a given query source
+        /// </summary>
+        /// <param name="querySource">IQuerySource for which to get the extent name</param>
+        /// <returns>The escaped extent name for the N1QL query</returns>
+        public string GetExtentName(IQuerySource querySource)
+        {
+            if (querySource == null)
+            {
+                throw new ArgumentNullException("querySource");
+            }
+
+            if (Prefix != null)
+            {
+                return Prefix + GetExtentNameUnprefixed(querySource);
+            }
+            else
+            {
+                return GetExtentNameUnprefixed(querySource);
+            }
+        }
+
+        /// <summary>
+        /// Provides the extent name for a given query source, before the Prefix is applied
+        /// </summary>
+        /// <param name="querySource">IQuerySource for which to get the extent name</param>
+        /// <returns>The escaped extent name for the N1QL query</returns>
+        private string GetExtentNameUnprefixed(IQuerySource querySource)
+        {
+            string extentName;
+            if (!_extentDictionary.TryGetValue(querySource, out extentName))
+            {
+                extentName = GetNextExtentName();
+
+                _extentDictionary.Add(querySource, extentName);
+            }
+
+            return extentName;
+        }
+
+        /// <summary>
+        /// Links two extents together so they share the same name
+        /// </summary>
+        /// <param name="primaryExtent">Extent to link to, which may or may not already have a name</param>
+        /// <param name="secondaryExtent">New extent to share the name of the primaryExtent</param>
+        /// <returns>
+        /// Primarily used when handling join clauses that join to subqueries.  This allows the subquery from
+        /// clause to share the same name as the join clause itself, since they are being merged into a single
+        /// join clause in the N1QL query output.
+        /// </returns>
+        public void LinkExtents(IQuerySource primaryExtent, IQuerySource secondaryExtent)
+        {
+            if (primaryExtent == null)
+            {
+                throw new ArgumentNullException("primaryExtent");
+            }
+            if (secondaryExtent == null)
+            {
+                throw new ArgumentNullException("secondaryExtent");
+            }
+
+            if (_extentDictionary.ContainsKey(secondaryExtent))
+            {
+                throw new InvalidOperationException("The given secondaryExtent has already been generated a unique extent name");
+            }
+
+            _extentDictionary.Add(secondaryExtent, GetExtentNameUnprefixed(primaryExtent));
+        }
+
+        /// <summary>
+        /// Generates a one-time use extent name, which isn't linked to an IQuerySource
+        /// </summary>
+        /// <returns>The escaped extent name for the N1QL query</returns>
+        public string GetUnlinkedExtentName()
+        {
+            return GetNextExtentName();
+        }
+
+        public void SetBlankExtentName(IQuerySource querySource)
+        {
+            _extentDictionary[querySource] = "";
+        }
+
+        public void SetExtentName(IQuerySource querySource, string extentName)
+        {
+            if (querySource == null)
+            {
+                throw new ArgumentNullException("extentName");
+            }
+            if (string.IsNullOrEmpty(extentName))
+            {
+                return;
+            }
+
+            if (_extentDictionary.ContainsKey(querySource))
+            {
+                throw new InvalidOperationException("Cannot set the extent name on a query source which already has a name.");
+            }
+
+            _extentDictionary[querySource] = N1QlHelpers.EscapeIdentifier(extentName);
+        }
+
+        /// <summary>
+        /// Change the extent name of a query source to a newly generated name, replacing any previously generated name.
+        /// </summary>
+        /// <param name="querySource">IQuerySource for which to get a new extent name</param>
+        /// <returns>The escaped extent name for the N1QL query</returns>
+        public string GenerateNewExtentName(IQuerySource querySource)
+        {
+            if (querySource == null)
+            {
+                throw new ArgumentNullException("querySource");
+            }
+
+            // Remove the extent name, if already generated
+            _extentDictionary.Remove(querySource);
+
+            // Generate and return a new extent name
+            return GetExtentName(querySource);
+        }
+
+        private string GetNextExtentName()
+        {
+            return N1QlHelpers.EscapeIdentifier(string.Format(ExtentNameFormat, ++_extentIndex));
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/N1QlHelpers.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/N1QlHelpers.cs
@@ -1,0 +1,61 @@
+﻿using System;
+
+namespace Couchbase.EntityFramework.QueryGeneration
+{
+    /// <summary>
+    /// Helpers for N1QL query generation
+    /// </summary>
+    internal static class N1QlHelpers
+    {
+
+        /// <summary>
+        ///     Escapes a N1QL identifier using tick (`) characters
+        /// </summary>
+        /// <param name="identifier">The identifier to format</param>
+        /// <returns>An escaped identifier</returns>
+        public static string EscapeIdentifier(string identifier)
+        {
+            if (identifier == null)
+            {
+                throw new ArgumentNullException("identifier");
+            }
+
+            if (identifier.IndexOf('`') >= 0)
+            {
+                // This should not occur, and is primarily in place to prevent N1QL injection attacks
+                // So it isn't performance critical to perform this replace in a StringBuilder with the concatenation
+
+                identifier = identifier.Replace("`", "``");
+            }
+
+            return string.Concat("`", identifier, "`");
+        }
+
+        /// <summary>
+        /// Checks to see if the identifier may be a valid keyword.
+        /// </summary>
+        /// <param name="identifier">Identifier to check.</param>
+        /// <returns>True if the identifier may be a valid keyword.</returns>
+        /// <remarks>This method doesn't guarantee that they identifier is a currently known N1QL keyword, as this list
+        /// may change over time.  It merely confirms that it is formatted as a plain string of alphabetic characters which
+        /// may be a single keyword.  This provides security control against N1QL injection attacks where a single keyword
+        /// is known to be safe but additional characters could be malicious.</remarks>
+        public static bool IsValidKeyword(string identifier)
+        {
+            if (string.IsNullOrWhiteSpace(identifier))
+            {
+                return false;
+            }
+
+            for (var i = 0; i < identifier.Length; i++)
+            {
+                if (!char.IsLetter(identifier, i))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/N1QlQueryGenerationContext.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/N1QlQueryGenerationContext.cs
@@ -1,0 +1,55 @@
+﻿using Couchbase.Core.Serialization;
+using Couchbase.Core.Version;
+using Couchbase.EntityFramework.QueryGeneration.MemberNameResolvers;
+using Remotion.Linq.Clauses.Expressions;
+
+namespace Couchbase.EntityFramework.QueryGeneration
+{
+    /// <summary>
+    /// Used to pass query generation context between various classes
+    /// </summary>
+    internal class N1QlQueryGenerationContext
+    {
+        public N1QlExtentNameProvider ExtentNameProvider { get; set; }
+        public IMemberNameResolver MemberNameResolver { get; set; }
+        public IMethodCallTranslatorProvider MethodCallTranslatorProvider { get; set; }
+        public ParameterAggregator ParameterAggregator { get; set; }
+        public ITypeSerializer Serializer { get; set; }
+        public ClusterVersion ClusterVersion { get; set; }
+
+        /// <summary>
+        /// Stores a reference to the current grouping subquery
+        /// </summary>
+        public QuerySourceReferenceExpression GroupingQuerySource { get; set; }
+
+        /// <summary>
+        /// If true, indicates that the document metadata should also be included in the select projection as "__metadata"
+        /// </summary>
+        public bool SelectDocumentMetadata { get; set; }
+
+        public N1QlQueryGenerationContext()
+        {
+            ExtentNameProvider = new N1QlExtentNameProvider();
+            ParameterAggregator = new ParameterAggregator();
+        }
+
+        /// <summary>
+        /// Clones this N1QlQueryGenerationContext for use within a union secondary query
+        /// </summary>
+        public N1QlQueryGenerationContext CloneForUnion()
+        {
+            // In the future we may want some properties get new values when working in a union
+            // This method provides a simple point for this extension
+
+            return new N1QlQueryGenerationContext()
+            {
+                ExtentNameProvider = ExtentNameProvider,
+                MemberNameResolver = MemberNameResolver,
+                MethodCallTranslatorProvider = MethodCallTranslatorProvider,
+                ParameterAggregator = ParameterAggregator,
+                Serializer = Serializer,
+                ClusterVersion = ClusterVersion
+            };
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/NamedParameter.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/NamedParameter.cs
@@ -1,0 +1,8 @@
+﻿namespace Couchbase.EntityFramework.QueryGeneration
+{
+    internal sealed class NamedParameter
+    {
+        public string Name { get; set; }
+        public object Value { get; set; }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/ParameterAggregator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/ParameterAggregator.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace Couchbase.EntityFramework.QueryGeneration
+{
+    internal sealed class ParameterAggregator
+    {
+        private readonly List<NamedParameter> _parameters = new List<NamedParameter>();
+
+        public NamedParameter AddNamedParameter(object value)
+        {
+            var parameter = new NamedParameter
+            {
+                Value = value,
+                Name = string.Concat("p", _parameters.Count + 1)
+            };
+            _parameters.Add(parameter);
+            return parameter;
+        }
+
+        public NamedParameter[] GetNamedParameters()
+        {
+            return _parameters.ToArray();
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/QueryPartsAggregator.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/QueryPartsAggregator.cs
@@ -1,0 +1,542 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Couchbase.EntityFramework.QueryGeneration.FromParts;
+using Couchbase.Logging;
+
+namespace Couchbase.EntityFramework.QueryGeneration
+{
+    internal class QueryPartsAggregator
+    {
+        private readonly ILog _log = LogManager.GetLogger<QueryPartsAggregator>();
+
+        public QueryPartsAggregator()
+        {
+            Extents = new List<ExtentPart>();
+            LetParts = new List<N1QlLetQueryPart>();
+            WhereParts = new List<string>();
+            OrderByParts = new List<string>();
+        }
+
+        public string SelectPart { get; set; }
+        public List<ExtentPart> Extents { get; set; }
+        public string UseKeysPart { get; set; }
+        public List<N1QlLetQueryPart> LetParts { get; set; }
+        public List<string> WhereParts { get; set; }
+        public List<string> OrderByParts { get; set; }
+        public List<string> GroupByParts { get; set; }
+        public List<string> HavingParts { get; set; }
+        public string LimitPart { get; set; }
+        public string OffsetPart { get; set; }
+        public string DistinctPart { get; set; }
+        public string ExplainPart { get; set; }
+        public string MetaPart { get; set; }
+        public string WhereAllPart { get; set; }
+        /// <summary>
+        /// For subqueries, stores the name of property to extract to a plain array
+        /// </summary>
+        public string PropertyExtractionPart { get; set; }
+        /// <summary>
+        /// For Array subqueries, list of functions to wrap the result
+        /// </summary>
+        public List<string> WrappingFunctions { get; set; }
+        /// <summary>
+        /// For aggregates, wraps the SelectPart with this function call
+        /// </summary>
+        public string AggregateFunction { get; set; }
+        /// <summary>
+        /// UNION statements appended to the end of this query
+        /// </summary>
+        public List<string> UnionParts { get; set; }
+
+        /// <summary>
+        /// If true, then SELECT RAW should be used instead of a plain SELCT
+        /// </summary>
+        public bool RawSelection { get; set; }
+
+        /// <summary>
+        /// Indicates the type of query or subquery being generated
+        /// </summary>
+        /// <remarks>
+        /// Defaults to building a SELECT query
+        /// </remarks>
+        public N1QlQueryType QueryType { get; set; }
+
+        /// <summary>
+        /// Returns true if the QueryType is a bucket-based subquery
+        /// </summary>
+        public bool IsBucketSubquery
+        {
+            get
+            {
+                return (QueryType == N1QlQueryType.Subquery) || (QueryType == N1QlQueryType.SubqueryAny) ||
+                       (QueryType == N1QlQueryType.SubqueryAll);
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the QueryType is an array-based subquery
+        /// </summary>
+        public bool IsArraySubquery
+        {
+            get
+            {
+                return (QueryType == N1QlQueryType.Array) || (QueryType == N1QlQueryType.ArrayAny) ||
+                       (QueryType == N1QlQueryType.ArrayAll);
+            }
+        }
+
+        public void AddWhereMissingPart(string format, params object[] args)
+        {
+            WhereParts.Add(string.Format(format, args));
+        }
+
+        public void AddWherePart(string format, params object[] args)
+        {
+            WhereParts.Add(string.Format(format, args));
+        }
+
+        public void AddExtent(ExtentPart fromPart)
+        {
+            Extents.Add(fromPart);
+        }
+
+        public void AddUseKeysPart(string useKeysPart)
+        {
+            if (!string.IsNullOrEmpty(UseKeysPart))
+            {
+                throw new InvalidOperationException("AddUseKeysPart May Only Be Called Once");
+            }
+
+            UseKeysPart = useKeysPart;
+        }
+
+        public void AddLetPart(N1QlLetQueryPart letPart)
+        {
+            LetParts.Add(letPart);
+        }
+
+        public void AddDistinctPart(string value)
+        {
+            DistinctPart = value;
+        }
+
+        /// <summary>
+        /// Adds an expression to the comma-delimited list of the GROUP BY clause
+        /// </summary>
+        public void AddGroupByPart(string value)
+        {
+            if (GroupByParts == null)
+            {
+                GroupByParts = new List<string>();
+            }
+
+            GroupByParts.Add(value);
+        }
+
+        /// <summary>
+        /// Adds an expression to the HAVING clause, ANDed with any other expressions
+        /// </summary>
+        public void AddHavingPart(string value)
+        {
+            if (HavingParts == null)
+            {
+                HavingParts = new List<string>();
+            }
+
+            HavingParts.Add(value);
+        }
+
+        private void ApplyLetParts(StringBuilder sb)
+        {
+            for (var i = 0; i < LetParts.Count; i++)
+            {
+                if (i == 0)
+                {
+                    sb.Append(" LET ");
+                }
+                else
+                {
+                    sb.Append(", ");
+                }
+
+                sb.AppendFormat("{0} = {1}", LetParts[i].ItemName, LetParts[i].Value);
+            }
+        }
+
+        public void AddWrappingFunction(string function)
+        {
+            if (WrappingFunctions == null)
+            {
+                WrappingFunctions = new List<string>();
+            }
+
+            WrappingFunctions.Add(function);
+        }
+
+        public void AddUnionPart(string unionPart)
+        {
+            if (UnionParts == null)
+            {
+                UnionParts = new List<string>();
+            }
+
+            UnionParts.Add(unionPart);
+        }
+
+        /// <summary>
+        /// Builds a primary select query
+        /// </summary>
+        /// <returns>Query string</returns>
+        private string BuildSelectQuery()
+        {
+            var sb = new StringBuilder();
+
+            if (QueryType == N1QlQueryType.Subquery)
+            {
+                if (!string.IsNullOrEmpty(PropertyExtractionPart))
+                {
+                    // Subqueries will always return a list of objects
+                    // But we need to use an ARRAY statement to convert it into an array of a particular property of that object
+
+                    sb.AppendFormat("ARRAY `ArrayExtent`.{0} FOR `ArrayExtent` IN (", PropertyExtractionPart);
+                }
+                else
+                {
+                    sb.Append('(');
+                }
+            }
+            else if (QueryType == N1QlQueryType.SubqueryAny)
+            {
+                sb.AppendFormat("ANY {0} IN (", PropertyExtractionPart);
+            }
+            else if (QueryType == N1QlQueryType.SubqueryAll)
+            {
+                sb.AppendFormat("EVERY {0} IN (", PropertyExtractionPart);
+            }
+
+            if (!string.IsNullOrWhiteSpace(ExplainPart))
+            {
+                sb.Append(ExplainPart);
+            }
+
+            sb.Append("SELECT ");
+            if (RawSelection)
+            {
+                sb.Append("RAW ");
+            }
+
+            if (!string.IsNullOrEmpty(AggregateFunction))
+            {
+                sb.AppendFormat("{0}({1}{2})",
+                    AggregateFunction,
+                    !string.IsNullOrWhiteSpace(DistinctPart) ? DistinctPart : string.Empty,
+                    SelectPart);
+            }
+            else
+            {
+                sb.AppendFormat("{0}{1}",
+                    !string.IsNullOrWhiteSpace(DistinctPart) ? DistinctPart : string.Empty,
+                    SelectPart);
+                //TODO support multiple select parts: http://localhost:8093/tutorial/content/#5
+            }
+
+            if (!IsBucketSubquery && !string.IsNullOrEmpty(PropertyExtractionPart))
+            {
+                sb.AppendFormat(" as {0}", PropertyExtractionPart);
+            }
+
+            if (Extents.Any())
+            {
+                var mainFrom = Extents.First();
+                mainFrom.AppendToStringBuilder(sb);
+
+                if (!string.IsNullOrEmpty(UseKeysPart))
+                {
+                    sb.AppendFormat(" USE KEYS {0}", UseKeysPart);
+                }
+
+                foreach (var joinPart in Extents.Skip(1))
+                {
+                    joinPart.AppendToStringBuilder(sb);
+                }
+            }
+
+            ApplyLetParts(sb);
+
+            if (WhereParts.Any())
+            {
+                sb.AppendFormat(" WHERE {0}", String.Join(" AND ", WhereParts));
+            }
+            if ((GroupByParts != null) && GroupByParts.Any())
+            {
+                sb.AppendFormat(" GROUP BY {0}", string.Join(", ", GroupByParts));
+            }
+            if ((HavingParts != null) && HavingParts.Any())
+            {
+                sb.AppendFormat(" HAVING {0}", string.Join(" AND ", HavingParts));
+            }
+
+            if (UnionParts != null)
+            {
+                sb.Append(string.Join("", UnionParts));
+            }
+
+            if (OrderByParts.Any())
+            {
+                sb.AppendFormat(" ORDER BY {0}", String.Join(", ", OrderByParts));
+            }
+            if (LimitPart != null)
+            {
+                sb.Append(LimitPart);
+            }
+            if (LimitPart != null && OffsetPart != null)
+            {
+                sb.Append(OffsetPart);
+            }
+
+            if (QueryType == N1QlQueryType.Subquery)
+            {
+                if (!string.IsNullOrEmpty(PropertyExtractionPart))
+                {
+                    sb.Append(") END");
+                }
+                else
+                {
+                    sb.Append(')');
+                }
+            }
+            else if (QueryType == N1QlQueryType.SubqueryAny)
+            {
+                sb.Append(") SATISFIES true END");
+            }
+            else if (QueryType == N1QlQueryType.SubqueryAll)
+            {
+                sb.AppendFormat(") SATISFIES {0} END", WhereAllPart);
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Builds a main query to return an Any or All result
+        /// </summary>
+        /// <returns>Query string</returns>
+        private string BuildMainAnyAllQuery()
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendFormat("SELECT {0} as result",
+                QueryType == N1QlQueryType.MainQueryAny ? "true" : "false");
+
+            if (Extents.Any())
+            {
+                var mainFrom = Extents.First();
+                mainFrom.AppendToStringBuilder(sb);
+
+                if (!string.IsNullOrEmpty(UseKeysPart))
+                {
+                    sb.AppendFormat(" USE KEYS {0}", UseKeysPart);
+                }
+
+                foreach (var joinPart in Extents.Skip(1))
+                {
+                    joinPart.AppendToStringBuilder(sb);
+                }
+            }
+
+            ApplyLetParts(sb);
+
+            bool hasWhereClause = false;
+            if (WhereParts.Any())
+            {
+                sb.AppendFormat(" WHERE {0}", String.Join(" AND ", WhereParts));
+
+                hasWhereClause = true;
+            }
+
+            if (QueryType == N1QlQueryType.MainQueryAll)
+            {
+                sb.AppendFormat(" {0} NOT ({1})",
+                    hasWhereClause ? "AND" : "WHERE",
+                    WhereAllPart);
+            }
+
+            sb.Append(" LIMIT 1");
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Build a subquery against a nested array property
+        /// </summary>
+        /// <returns></returns>
+        private string BuildArrayQuery()
+        {
+            var sb = new StringBuilder();
+
+            var mainFrom = Extents.FirstOrDefault();
+            if (mainFrom == null)
+            {
+                throw new InvalidOperationException("N1QL Subquery Missing From Part");
+            }
+
+            if (WrappingFunctions != null)
+            {
+                foreach (string function in WrappingFunctions.AsEnumerable().Reverse())
+                {
+                    sb.AppendFormat("{0}(", function);
+                }
+            }
+
+            if ((SelectPart != mainFrom.ItemName) || WhereParts.Any())
+            {
+                sb.AppendFormat("ARRAY {0} FOR {1} IN {2}", SelectPart, mainFrom.ItemName, mainFrom.Source);
+
+                if (WhereParts.Any())
+                {
+                    sb.AppendFormat(" WHEN {0}", String.Join(" AND ", WhereParts));
+                }
+
+                sb.Append(" END");
+            }
+            else
+            {
+                // has no projection or predicates, so simplify
+
+                sb.Append(mainFrom.Source);
+            }
+
+            if (WrappingFunctions != null)
+            {
+                sb.Append(')', WrappingFunctions.Count);
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Builds a subquery using the ANY or EVERY expression to test a nested array
+        /// </summary>
+        /// <returns>Query string</returns>
+        private string BuildAnyAllQuery()
+        {
+            var sb = new StringBuilder();
+
+            var mainFrom = Extents.FirstOrDefault();
+            if (mainFrom == null)
+            {
+                throw new InvalidOperationException("N1QL Any Subquery Missing From Part");
+            }
+
+            var extentName = mainFrom.ItemName;
+
+            var source = mainFrom.Source;
+            if (QueryType == N1QlQueryType.ArrayAll)
+            {
+                extentName = PropertyExtractionPart;
+
+                if (WhereParts.Any())
+                {
+                    // WhereParts should be used to filter the source before the EVERY query
+                    // This is done using the ARRAY operator with a WHEN clause
+
+                    source = string.Format("(ARRAY {1} FOR {1} IN {0} WHEN {2} END)",
+                        source,
+                        mainFrom.ItemName,
+                        string.Join(" AND ", WhereParts));
+                }
+            }
+
+            sb.AppendFormat("{0} {1} IN {2} ",
+                QueryType == N1QlQueryType.ArrayAny ? "ANY" : "EVERY",
+                extentName,
+                source);
+
+            if (QueryType == N1QlQueryType.ArrayAny)
+            {
+                // WhereParts should be applied to the SATISFIES portion of the query
+
+                if (WhereParts.Any())
+                {
+                    sb.AppendFormat("SATISFIES {0}", String.Join(" AND ", WhereParts));
+                }
+                else
+                {
+                    sb.Append("SATISFIES true");
+                }
+            }
+            else // N1QlQueryType.All
+            {
+                // WhereAllPart is applied as the SATISFIES portion of the query
+
+                sb.Append("SATISFIES ");
+                sb.Append(WhereAllPart);
+            }
+
+            sb.Append(" END");
+
+            return sb.ToString();
+        }
+
+        private string BuildAggregate()
+        {
+            return string.Format("{0}({1})", AggregateFunction, SelectPart);
+        }
+
+        public string BuildN1QlQuery()
+        {
+            string query;
+
+            switch (QueryType)
+            {
+                case N1QlQueryType.Select:
+                case N1QlQueryType.Subquery:
+                case N1QlQueryType.SubqueryAny:
+                case N1QlQueryType.SubqueryAll:
+                    query = BuildSelectQuery();
+                    break;
+
+                case N1QlQueryType.Array:
+                    query = BuildArrayQuery();
+                    break;
+
+                case N1QlQueryType.ArrayAny:
+                case N1QlQueryType.ArrayAll:
+                    query = BuildAnyAllQuery();
+                    break;
+
+                case N1QlQueryType.MainQueryAny:
+                case N1QlQueryType.MainQueryAll:
+                    query = BuildMainAnyAllQuery();
+                    break;
+
+                case N1QlQueryType.Aggregate:
+                    query = BuildAggregate();
+                    break;
+
+                default:
+                    throw new InvalidOperationException(string.Format("Unsupported N1QlQueryType: {0}", QueryType));
+            }
+
+            _log.Debug(query);
+            return query;
+        }
+
+        public void AddOffsetPart(string offsetPart, int count)
+        {
+            OffsetPart = String.Format(offsetPart, count);
+        }
+
+        public void AddLimitPart(string limitPart, int count)
+        {
+            LimitPart = String.Format(limitPart, count);
+        }
+
+        public void AddOrderByPart(IEnumerable<string> orderings)
+        {
+            OrderByParts.Insert(0, String.Join(", ", orderings));
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryGeneration/UnclaimedGroupJoin.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/UnclaimedGroupJoin.cs
@@ -1,0 +1,12 @@
+﻿using Remotion.Linq.Clauses;
+
+namespace Couchbase.EntityFramework.QueryGeneration
+{
+    internal class UnclaimedGroupJoin
+    {
+
+        public JoinClause JoinClause { get; set; }
+        public GroupJoinClause GroupJoinClause { get; set; }
+
+    }
+}

--- a/src/Couchbase.EntityFramework/QueryParserHelper.cs
+++ b/src/Couchbase.EntityFramework/QueryParserHelper.cs
@@ -1,0 +1,103 @@
+﻿using Couchbase.EntityFramework.Clauses;
+using Couchbase.EntityFramework.Operators;
+using Couchbase.EntityFramework.QueryGeneration.ExpressionTransformers;
+using Couchbase.EntityFramework.Serialization;
+using Couchbase.EntityFramework.Utils;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
+using Remotion.Linq.Parsing.Structure;
+using Remotion.Linq.Parsing.Structure.ExpressionTreeProcessors;
+using Remotion.Linq.Parsing.Structure.NodeTypeProviders;
+
+namespace Couchbase.EntityFramework
+{
+    internal class QueryParserHelper
+    {
+        private static readonly INodeTypeProvider _nodeTypeProvider;
+        private static readonly ExpressionTransformerRegistry _transformerRegistry;
+        private static readonly ExpressionTransformerRegistry _prePartialEvaluationTransformerRegistry;
+
+        static QueryParserHelper()
+        {
+            _nodeTypeProvider = CreateDefaultNodeTypeProvider();
+            _transformerRegistry = CreateDefaultTransformerRegistry();
+            _prePartialEvaluationTransformerRegistry = CreatePrePartialEvaluationDefaultTransformerRegistry();
+        }
+
+        private static INodeTypeProvider CreateDefaultNodeTypeProvider()
+        {
+            //Create Custom node registry
+            var nodeTypeRegistry = new MethodInfoBasedNodeTypeRegistry();
+
+            //register the "Nest" clause type
+            nodeTypeRegistry.Register(NestExpressionNode.SupportedMethods,
+                typeof(NestExpressionNode));
+
+            //register the "Explain" expression node parser
+            nodeTypeRegistry.Register(ExplainExpressionNode.SupportedMethods,
+                typeof(ExplainExpressionNode));
+
+            //register the "UseKeys" expression node parser
+            nodeTypeRegistry.Register(UseKeysExpressionNode.SupportedMethods,
+                typeof(UseKeysExpressionNode));
+
+            //register the "UseIndex" expression node parser
+            nodeTypeRegistry.Register(UseIndexExpressionNode.SupportedMethods,
+                typeof(UseIndexExpressionNode));
+
+            //register the "UseHash" expression node parser
+            nodeTypeRegistry.Register(UseHashExpressionNode.SupportedMethods,
+                typeof(UseHashExpressionNode));
+
+            //register the "ExtentName" expression node parser
+            nodeTypeRegistry.Register(ExtentNameExpressionNode.SupportedMethods,
+                typeof(ExtentNameExpressionNode));
+
+            //register the "ToQueryRequest" expression node parser
+            nodeTypeRegistry.Register(ToQueryRequestExpressionNode.SupportedMethods,
+                typeof(ToQueryRequestExpressionNode));
+
+            //This creates all the default node types
+            var nodeTypeProvider = ExpressionTreeParser.CreateDefaultNodeTypeProvider();
+
+            //add custom node provider to the providers
+            nodeTypeProvider.InnerProviders.Add(nodeTypeRegistry);
+
+            return nodeTypeProvider;
+        }
+
+        private static ExpressionTransformerRegistry CreateDefaultTransformerRegistry()
+        {
+            var transformerRegistry = ExpressionTransformerRegistry.CreateDefault();
+
+            //Register transformer to handle string comparisons
+            transformerRegistry.Register(new StringComparisonExpressionTransformer());
+
+            //Register transformer to handle DateTime comparisons
+            transformerRegistry.Register(new DateTimeComparisonExpressionTransformer());
+
+            return transformerRegistry;
+        }
+
+        private static ExpressionTransformerRegistry CreatePrePartialEvaluationDefaultTransformerRegistry()
+        {
+            var transformerRegistry = ExpressionTransformerRegistry.CreateDefault();
+
+            //Register transformer to handle enum == and != comparisons
+            transformerRegistry.Register(new EnumComparisonExpressionTransformer());
+
+            return transformerRegistry;
+        }
+
+        public static IQueryParser CreateQueryParser(IBucketContext bucketContext) =>
+            new QueryParser(
+                new ExpressionTreeParser(
+                    _nodeTypeProvider,
+                    new CompoundExpressionTreeProcessor(new IExpressionTreeProcessor[]
+                    {
+                        new TransformingExpressionTreeProcessor(_prePartialEvaluationTransformerRegistry),
+                        SerializationExpressionTreeProcessor.FromBucketContext(bucketContext),
+                        new PartialEvaluatingExpressionTreeProcessor(new ExcludeSerializationConversionEvaluatableExpressionFilter()),
+                        new TransformingExpressionTreeProcessor(_transformerRegistry)
+                    })));
+    }
+}

--- a/src/Couchbase.EntityFramework/SaveOptions.cs
+++ b/src/Couchbase.EntityFramework/SaveOptions.cs
@@ -1,0 +1,24 @@
+﻿namespace Couchbase.EntityFramework
+{
+    /// <summary>
+    /// Provides options controlling how changes are saved via <see cref="IBucketContext"/>.
+    /// </summary>
+    public class SaveOptions
+    {
+        /// <summary>
+        /// If true, before saving documents the Couchbase bucket is checked to ensure that another process
+        /// has not modified the document since it was read.  If it was modified, a
+        /// <see cref="CouchbaseConsistencyException"/> is thrown.  For new documents, the exception will be
+        /// thrown if the document already exists.  Defaults to true.
+        /// </summary>
+        public bool PerformConsistencyCheck { get; set; }
+
+        /// <summary>
+        /// Creates a new <see cref="SaveOptions"/> object.
+        /// </summary>
+        public SaveOptions()
+        {
+            PerformConsistencyCheck = true;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Serialization/Converters/SerializationConverterBase.cs
+++ b/src/Couchbase.EntityFramework/Serialization/Converters/SerializationConverterBase.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.QueryGeneration;
+using Couchbase.Linq.Serialization;
+
+namespace Couchbase.EntityFramework.Serialization.Converters
+{
+    public abstract class SerializationConverterBase : ISerializationConverter
+    {
+        /// <summary>
+        /// Dictionary of <see cref="ISerializationConverter{T}.ConvertFrom"/> methods implemented
+        /// by this type, indexed by the type being converted.
+        /// </summary>
+        /// <remarks>
+        /// Implementation should return a statically allocated dictionary for performance.
+        /// </remarks>
+        protected abstract IDictionary<Type, MethodInfo> ConvertFromMethods { get; }
+
+        /// <summary>
+        /// Dictionary of <see cref="ISerializationConverter{T}.ConvertTo"/> methods implemented
+        /// by this type, indexed by the type being converted.
+        /// </summary>
+        /// <remarks>
+        /// Implementation should return a statically allocated dictionary for performance.
+        /// </remarks>
+        protected abstract IDictionary<Type, MethodInfo> ConvertToMethods { get; }
+
+        /// <summary>
+        /// Renders a conversion from the standard format to the custom format onto a N1QL query.
+        /// </summary>
+        /// <param name="innerExpression">The expression being converted.</param>
+        /// <param name="expressionTreeVisitor"><see cref="IN1QlExpressionTreeVisitor"/> rendering the query.</param>
+        protected abstract void RenderConvertToMethod(Expression innerExpression,
+            IN1QlExpressionTreeVisitor expressionTreeVisitor);
+
+        /// <summary>
+        /// Renders a conversion from the custom format to the standard format onto a N1QL query.
+        /// </summary>
+        /// <param name="innerExpression">The expression being converted.</param>
+        /// <param name="expressionTreeVisitor"><see cref="IN1QlExpressionTreeVisitor"/> rendering the query.</param>
+        protected abstract void RenderConvertFromMethod(Expression innerExpression,
+            IN1QlExpressionTreeVisitor expressionTreeVisitor);
+
+        /// <summary>
+        /// Renders a constant which has been preconverted to the custom format onto a N1QL query.
+        /// </summary>
+        /// <param name="constantExpression">The expression being converted.</param>
+        /// <param name="expressionTreeVisitor"><see cref="IN1QlExpressionTreeVisitor"/> rendering the query.</param>
+        protected abstract void RenderConvertedConstant(ConstantExpression constantExpression,
+            IN1QlExpressionTreeVisitor expressionTreeVisitor);
+
+        /// <inheritdoc/>
+        public Expression GenerateConvertToExpression(Expression innerExpression)
+        {
+            if (ConvertToMethods.TryGetValue(innerExpression.Type, out var conversionMethod))
+            {
+                return ApplyConversion(innerExpression, conversionMethod);
+            }
+
+            return innerExpression;
+        }
+
+        /// <inheritdoc/>
+        public Expression GenerateConvertFromExpression(Expression innerExpression)
+        {
+            if (ConvertFromMethods.TryGetValue(innerExpression.Type, out var conversionMethod))
+            {
+                return ApplyConversion(innerExpression, conversionMethod);
+            }
+
+            return innerExpression;
+        }
+
+        /// <inheritdoc/>
+        public virtual void RenderConvertTo(Expression innerExpression, IN1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            var unwrapped = UnwrapInverseMethod(innerExpression, ConvertFromMethods.Values);
+            if (unwrapped != null)
+            {
+                expressionTreeVisitor.Visit(unwrapped);
+            }
+            else if (innerExpression is ConstantExpression constantExpression)
+            {
+                RenderConvertedConstant(constantExpression, expressionTreeVisitor);
+            }
+            else
+            {
+                RenderConvertToMethod(innerExpression, expressionTreeVisitor);
+            }
+        }
+
+        /// <inheritdoc/>
+        public virtual void RenderConvertFrom(Expression innerExpression, IN1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            var unwrapped = UnwrapInverseMethod(innerExpression, ConvertToMethods.Values);
+            if (unwrapped != null)
+            {
+                expressionTreeVisitor.Visit(unwrapped);
+            }
+            else
+            {
+                RenderConvertFromMethod(innerExpression, expressionTreeVisitor);
+            }
+        }
+
+        /// <summary>
+        /// Wraps an expression in a call to a conversion method.
+        /// </summary>
+        /// <param name="expression">Expression to wrap.</param>
+        /// <param name="conversionMethod">The conversion method.</param>
+        /// <returns>The wrapped expression.</returns>
+        /// <remarks>
+        /// The method must be an instance method of the class, and must accept a single parameter with the same type as the expression.
+        /// </remarks>
+        protected virtual Expression ApplyConversion(Expression expression, MethodInfo conversionMethod)
+        {
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+            if (conversionMethod == null)
+            {
+                throw new ArgumentNullException(nameof(conversionMethod));
+            }
+
+            return Expression.Call(
+                Expression.Constant(this),
+                conversionMethod,
+                expression);
+        }
+
+        /// <summary>
+        /// Tests to see if an expression is a method call to an inverse method, and if so it removes the call
+        /// to the inverse method.
+        /// </summary>
+        /// <param name="expression">Expression to unwrap.</param>
+        /// <param name="inverseMethods">List of inverse methods which should be removed.</param>
+        /// <returns>The expression with the inverse method removed, or null if no inverse method was found.</returns>
+        /// <remarks>
+        /// This is a helper method which assists with removing unnecessary conversions.  If a conversion method is
+        /// immediately followed by a call to its inverse, then neither is required.  Implementations of
+        /// <see cref="RenderConvertTo(Expression, IN1QlExpressionTreeVisitor)"/> and <see cref="RenderConvertFrom(Expression, IN1QlExpressionTreeVisitor)"/>
+        /// should use this method to avoid rendering unnecessary conversions.
+        /// </remarks>
+        protected virtual Expression UnwrapInverseMethod(Expression expression, ICollection<MethodInfo> inverseMethods)
+        {
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+            if (inverseMethods == null)
+            {
+                throw new ArgumentNullException(nameof(inverseMethods));
+            }
+
+            if (inverseMethods.Count > 0)
+            {
+                // We must handle convert calls, these are created when dealing with Nullable<T>
+                if (expression is UnaryExpression convertExpression &&
+                    convertExpression.NodeType == ExpressionType.Convert)
+                {
+                    if (convertExpression.Operand is MethodCallExpression convertMethodCall &&
+                        inverseMethods.Contains(convertMethodCall.Method))
+                    {
+                        return convertExpression.Update(convertMethodCall.Arguments[0]);
+                    }
+                }
+                else if (expression is MethodCallExpression innerMethodCall &&
+                         inverseMethods.Contains(innerMethodCall.Method))
+                {
+                    return innerMethodCall.Arguments[0];
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Collects <see cref="ISerializationConverter{T}.ConvertFrom"/> implementations from a given class.
+        /// </summary>
+        /// <typeparam name="T">Class from which conversion methods are being extracted.</typeparam>
+        /// <returns>Dictionary indexed by the type being converted.</returns>
+        protected static IDictionary<Type, MethodInfo> GetConvertFromMethods<T>()
+            where T: class
+        {
+            return GetConvertMethods(typeof(T), "ConvertFrom");
+        }
+
+        /// <summary>
+        /// Collects <see cref="ISerializationConverter{T}.ConvertTo"/> implementations from a given class.
+        /// </summary>
+        /// <typeparam name="T">Class from which conversion methods are being extracted.</typeparam>
+        /// <returns>Dictionary indexed by the type being converted.</returns>
+        protected static IDictionary<Type, MethodInfo> GetConvertToMethods<T>()
+            where T: class
+        {
+            return GetConvertMethods(typeof(T), "ConvertTo");
+        }
+
+        private static IDictionary<Type, MethodInfo> GetConvertMethods(Type type, string methodName)
+        {
+            return type
+                .GetInterfaces()
+                .Where(p => p.GetTypeInfo().IsGenericType && p.GetGenericTypeDefinition() == typeof(ISerializationConverter<>))
+                .ToDictionary(
+                    p => p.GetGenericArguments()[0],
+                    p => p.GetMethod(methodName));
+        }
+    }
+}
+

--- a/src/Couchbase.EntityFramework/Serialization/Converters/StringEnumSerializationConverter.cs
+++ b/src/Couchbase.EntityFramework/Serialization/Converters/StringEnumSerializationConverter.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.QueryGeneration;
+using Couchbase.Linq.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Couchbase.EntityFramework.Serialization.Converters
+{
+    public class StringEnumSerializationConverter<T> : SerializationConverterBase,
+        ISerializationConverter<T>, ISerializationConverter<T?>
+        where T: struct
+    {
+        // ReSharper disable StaticMemberInGenericType
+        private static readonly IDictionary<Type, MethodInfo> ConvertFromMethodsStatic =
+            GetConvertFromMethods<StringEnumSerializationConverter<T>>();
+
+        private static readonly IDictionary<Type, MethodInfo> ConvertToMethodsStatic =
+            GetConvertToMethods<StringEnumSerializationConverter<T>>();
+        // ReSharper restore StaticMemberInGenericType
+
+        /// <inheritdoc/>
+        protected override IDictionary<Type, MethodInfo> ConvertFromMethods => ConvertFromMethodsStatic;
+
+        /// <inheritdoc/>
+        protected override IDictionary<Type, MethodInfo> ConvertToMethods => ConvertToMethodsStatic;
+
+        private readonly JsonConverter _jsonConverter;
+        private readonly MemberInfo _member;
+
+        public StringEnumSerializationConverter(JsonConverter jsonConverter, MemberInfo member)
+        {
+            _jsonConverter = jsonConverter ?? throw new ArgumentNullException(nameof(jsonConverter));
+            _member = member ?? throw new ArgumentNullException(nameof(member));
+        }
+
+        /// <inheritdoc/>
+        T ISerializationConverter<T>.ConvertTo(T value)
+        {
+            return value;
+        }
+
+        /// <inheritdoc/>
+        T? ISerializationConverter<T?>.ConvertTo(T? value)
+        {
+            return value;
+        }
+
+        /// <inheritdoc/>
+        T ISerializationConverter<T>.ConvertFrom(T value)
+        {
+            return value;
+        }
+
+        /// <inheritdoc/>
+        T? ISerializationConverter<T?>.ConvertFrom(T? value)
+        {
+            return value;
+        }
+
+        /// <inheritdoc/>
+        protected override void RenderConvertToMethod(Expression innerExpression, IN1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            // Don't try to convert in N1QL, for enums we're only supporting constants as strings
+            expressionTreeVisitor.Visit(innerExpression);
+        }
+
+        /// <inheritdoc/>
+        protected override void RenderConvertFromMethod(Expression innerExpression, IN1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            // Don't try to convert in N1QL, for enums we're only supporting constants as strings
+            expressionTreeVisitor.Visit(innerExpression);
+        }
+
+        /// <inheritdoc/>
+        protected override void RenderConvertedConstant(ConstantExpression constantExpression, IN1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (constantExpression.Value == null)
+            {
+                // Don't try to convert nulls
+                expressionTreeVisitor.Visit(constantExpression);
+            }
+            else
+            {
+                using (var writer = new JTokenWriter())
+                {
+                    _jsonConverter.WriteJson(writer, constantExpression.Value,
+                        JsonSerializer.CreateDefault());
+
+                    expressionTreeVisitor.Visit(Expression.Constant(writer.Token.ToString()));
+                }
+            }
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Serialization/Converters/UnixMillisecondsSerializationConverter.cs
+++ b/src/Couchbase.EntityFramework/Serialization/Converters/UnixMillisecondsSerializationConverter.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.QueryGeneration;
+using Couchbase.Linq.Serialization;
+
+namespace Couchbase.EntityFramework.Serialization.Converters
+{
+    public class UnixMillisecondsSerializationConverter : SerializationConverterBase,
+        ISerializationConverter<DateTime>, ISerializationConverter<DateTime?>,
+        ISerializationConverter<DateTimeOffset>, ISerializationConverter<DateTimeOffset?>
+    {
+        private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        private static readonly IDictionary<Type, MethodInfo> ConvertFromMethodsStatic =
+            GetConvertFromMethods<UnixMillisecondsSerializationConverter>();
+
+        private static readonly IDictionary<Type, MethodInfo> ConvertToMethodsStatic =
+            GetConvertToMethods<UnixMillisecondsSerializationConverter>();
+
+        /// <inheritdoc/>
+        protected override IDictionary<Type, MethodInfo> ConvertFromMethods => ConvertFromMethodsStatic;
+
+        /// <inheritdoc/>
+        protected override IDictionary<Type, MethodInfo> ConvertToMethods => ConvertToMethodsStatic;
+
+        /// <inheritdoc/>
+        DateTime ISerializationConverter<DateTime>.ConvertTo(DateTime value)
+        {
+            return value;
+        }
+
+        /// <inheritdoc/>
+        DateTime? ISerializationConverter<DateTime?>.ConvertTo(DateTime? value)
+        {
+            return value;
+        }
+
+        /// <inheritdoc/>
+        DateTimeOffset ISerializationConverter<DateTimeOffset>.ConvertTo(DateTimeOffset value)
+        {
+            return value;
+        }
+
+        /// <inheritdoc/>
+        DateTimeOffset? ISerializationConverter<DateTimeOffset?>.ConvertTo(DateTimeOffset? value)
+        {
+            return value;
+        }
+
+        /// <inheritdoc/>
+        DateTime ISerializationConverter<DateTime>.ConvertFrom(DateTime value)
+        {
+            return value;
+        }
+
+        /// <inheritdoc/>
+        DateTime? ISerializationConverter<DateTime?>.ConvertFrom(DateTime? value)
+        {
+            return value;
+        }
+
+        /// <inheritdoc/>
+        DateTimeOffset ISerializationConverter<DateTimeOffset>.ConvertFrom(DateTimeOffset value)
+        {
+            return value;
+        }
+
+        /// <inheritdoc/>
+        DateTimeOffset? ISerializationConverter<DateTimeOffset?>.ConvertFrom(DateTimeOffset? value)
+        {
+            return value;
+        }
+
+        /// <inheritdoc/>
+        protected override void RenderConvertToMethod(Expression innerExpression, IN1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            expressionTreeVisitor.Expression.Append("STR_TO_MILLIS(");
+            expressionTreeVisitor.Visit(innerExpression);
+            expressionTreeVisitor.Expression.Append(')');
+        }
+
+        /// <inheritdoc/>
+        protected override void RenderConvertFromMethod(Expression innerExpression, IN1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            expressionTreeVisitor.Expression.Append("MILLIS_TO_STR(");
+            expressionTreeVisitor.Visit(innerExpression);
+            expressionTreeVisitor.Expression.Append(')');
+        }
+
+        /// <inheritdoc/>
+        protected override void RenderConvertedConstant(ConstantExpression constantExpression, IN1QlExpressionTreeVisitor expressionTreeVisitor)
+        {
+            if (constantExpression.Value == null)
+            {
+                // Don't try to convert nulls
+                expressionTreeVisitor.Visit(constantExpression);
+            }
+            else
+            {
+                var dateTime = GetDateTime(constantExpression);
+                var unixMilliseconds = (dateTime - UnixEpoch).TotalMilliseconds;
+
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if (Math.Floor(unixMilliseconds) == unixMilliseconds)
+                {
+                    expressionTreeVisitor.Expression.Append((long) unixMilliseconds);
+                }
+                else
+                {
+                    expressionTreeVisitor.Expression.Append(unixMilliseconds);
+                }
+            }
+        }
+
+        private static DateTime GetDateTime(ConstantExpression constantExpression)
+        {
+            switch (constantExpression.Value)
+            {
+                case DateTime dateTime:
+                    if (dateTime.Kind == DateTimeKind.Local)
+                    {
+                        dateTime = dateTime.ToUniversalTime();
+                    }
+
+                    return dateTime;
+
+                case DateTimeOffset offset:
+                    return offset.UtcDateTime;
+
+                default:
+                    throw new InvalidOperationException("ConstantExpression is not a DateTime or equivalent");
+            }
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Serialization/DefaultSerializationConverterProvider.cs
+++ b/src/Couchbase.EntityFramework/Serialization/DefaultSerializationConverterProvider.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Couchbase.Core.Serialization;
+using Couchbase.Linq.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Couchbase.EntityFramework.Serialization
+{
+    /// <summary>
+    /// Implementation of <see cref="ISerializationConverterProvider"/> used if the Couchbase serializer
+    /// doesn't implement the interface.  Checks for <see cref="JsonConverter"/> on the property
+    /// and uses a globally defined <see cref="Registry"/> to acquire an appropriate <see cref="ISerializationConverter"/>.
+    /// Only works Json.Net serialization, if using a custom serializer please implement
+    /// <see cref="ISerializationConverterProvider"/> directly on the serializer.
+    /// </summary>
+    public class DefaultSerializationConverterProvider : ISerializationConverterProvider
+    {
+        // Uses a weak table to track a cache for each ITypeSerializer/ISerializationConverterRegistry pair
+        // Because it's a weak table, this won't cause memory leaks and will cleanup as GC collects the serializers
+        private static readonly
+            ConditionalWeakTable<ITypeSerializer, ConcurrentDictionary<MemberInfo, ISerializationConverter>> CacheSet =
+                new ConditionalWeakTable<ITypeSerializer, ConcurrentDictionary<MemberInfo, ISerializationConverter>>();
+
+        private static IJsonNetSerializationConverterRegistry _registry =
+            TypeBasedSerializationConverterRegistry.Global;
+
+        /// <summary>
+        /// Registry of <see cref="ISerializationConverter"/> to use for a given <see cref="JsonConverter"/>.
+        /// By default, uses <see cref="TypeBasedSerializationConverterRegistry.Global"/>.
+        /// </summary>
+        public static IJsonNetSerializationConverterRegistry Registry
+        {
+            get => _registry;
+            set => _registry = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        private readonly ITypeSerializer _serializer;
+        private readonly ConcurrentDictionary<MemberInfo, ISerializationConverter> _cache;
+
+        public DefaultSerializationConverterProvider(ITypeSerializer serializer)
+        {
+            _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+
+            _cache = CacheSet.GetOrCreateValue(serializer);
+        }
+
+        /// <inheritdoc/>
+        public ISerializationConverter GetSerializationConverter(MemberInfo member)
+        {
+            if (member == null)
+            {
+                throw new ArgumentNullException(nameof(member));
+            }
+
+            if (!(_serializer is DefaultSerializer defaultSerializer))
+            {
+                // Default behavior
+                return null;
+            }
+
+            return _cache.GetOrAdd(member, p =>
+            {
+                if (defaultSerializer.SerializerSettings.ContractResolver.ResolveContract(member.DeclaringType) is JsonObjectContract contract)
+                {
+                    var property = contract.Properties.FirstOrDefault(
+                        q => q.UnderlyingName == member.Name && !q.Ignored);
+                    if (property != null)
+                    {
+                        var jsonConverter = GetJsonConverter(property, defaultSerializer);
+                        if (jsonConverter != null)
+                        {
+                            return Registry.CreateSerializationConverter(jsonConverter, p);
+                        }
+                    }
+                }
+
+                // Default behavior
+                return null;
+            });
+        }
+
+        private static JsonConverter GetJsonConverter(JsonProperty property, DefaultSerializer defaultSerializer)
+        {
+            if (property.Converter != null)
+            {
+                return property.Converter;
+            }
+
+            var valueContract = defaultSerializer.SerializerSettings.ContractResolver
+                .ResolveContract(property.PropertyType);
+            if (valueContract?.Converter != null)
+            {
+                return valueContract.Converter;
+            }
+
+            var converters = defaultSerializer.SerializerSettings.Converters;
+            return converters?.FirstOrDefault(p => p.CanConvert(property.PropertyType));
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Serialization/IJsonNetSerializationConverterRegistry.cs
+++ b/src/Couchbase.EntityFramework/Serialization/IJsonNetSerializationConverterRegistry.cs
@@ -1,0 +1,20 @@
+﻿using System.Reflection;
+using Newtonsoft.Json;
+
+namespace Couchbase.EntityFramework.Serialization
+{
+    /// <summary>
+    /// Registry of <see cref="ISerializationConverter"/> implementations based upon <see cref="JsonConverter"/>s.
+    /// </summary>
+    public interface IJsonNetSerializationConverterRegistry
+    {
+        /// <summary>
+        /// Creates an instance of an <see cref="ISerializationConverter"/> implementation for
+        /// a specific <see cref="JsonConverter"/>.  May return null.
+        /// </summary>
+        /// <param name="jsonConverter"><see cref="JsonConverter"/> to acquire.</param>
+        /// <param name="member">Member the converter is applied to.</param>
+        /// <returns>A new <see cref="ISerializationConverter"/>, or null if no converter is found.</returns>
+        ISerializationConverter CreateSerializationConverter(JsonConverter jsonConverter, MemberInfo member);
+    }
+}

--- a/src/Couchbase.EntityFramework/Serialization/ISerializationConverter.cs
+++ b/src/Couchbase.EntityFramework/Serialization/ISerializationConverter.cs
@@ -1,0 +1,50 @@
+﻿using System.Linq.Expressions;
+using Couchbase.EntityFramework.QueryGeneration;
+using Couchbase.Linq.Serialization;
+
+namespace Couchbase.EntityFramework.Serialization
+{
+    /// <summary>
+    /// A converter which represents conversions that normally take place during JSON serialization.
+    /// </summary>
+    public interface ISerializationConverter
+    {
+        /// <summary>
+        /// Wraps an expression to replicate the conversion which is happening during serialization.
+        /// </summary>
+        /// <param name="innerExpression">Expression to be converted.</param>
+        /// <returns>A new expression.</returns>
+        /// <remarks>
+        /// The in code representation of the conversion should be a noop.  It acts as a placeholder for query
+        /// generation.  The <see cref="RenderConvertTo"/> method will be called to render the N1QL equivalent
+        /// when the <see cref="ISerializationConverter{T}.ConvertTo"/> method is encountered.
+        /// </remarks>
+        Expression GenerateConvertToExpression(Expression innerExpression);
+
+        /// <summary>
+        /// Wraps an expression to replicate the inverse of the conversion which is happening during serialization.
+        /// </summary>
+        /// <param name="innerExpression">Expression to be converted.</param>
+        /// <returns>A new expression.</returns>
+        /// <remarks>
+        /// The in code representation of the conversion should be a noop.  It acts as a placeholder for query
+        /// generation.  The <see cref="RenderConvertTo"/> method will be called to render the N1QL equivalent
+        /// when the <see cref="ISerializationConverter{T}.ConvertFrom"/> method is encountered.
+        /// </remarks>
+        Expression GenerateConvertFromExpression(Expression innerExpression);
+
+        /// <summary>
+        /// Renders the conversion to a query string builder.
+        /// </summary>
+        /// <param name="innerExpression">Inner expression being converted.</param>
+        /// <param name="expressionTreeVisitor"><see cref="IN1QlExpressionTreeVisitor"/> used for rendering.</param>
+        void RenderConvertTo(Expression innerExpression, IN1QlExpressionTreeVisitor expressionTreeVisitor);
+
+        /// <summary>
+        /// Renders the inverse conversion to a query string builder.
+        /// </summary>
+        /// <param name="innerExpression">Inner expression being converted.</param>
+        /// <param name="expressionTreeVisitor"><see cref="IN1QlExpressionTreeVisitor"/> used for rendering.</param>
+        void RenderConvertFrom(Expression innerExpression, IN1QlExpressionTreeVisitor expressionTreeVisitor);
+    }
+}

--- a/src/Couchbase.EntityFramework/Serialization/ISerializationConverterProvider.cs
+++ b/src/Couchbase.EntityFramework/Serialization/ISerializationConverterProvider.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+using Couchbase.Core.Serialization;
+
+namespace Couchbase.EntityFramework.Serialization
+{
+    /// <summary>
+    /// Extension applied to <see cref="ITypeSerializer"/> implementations to provide
+    /// information about how members are serialized.
+    /// </summary>
+    public interface ISerializationConverterProvider
+    {
+        /// <summary>
+        /// Provides information about how a member is converted when it is serialized.
+        /// </summary>
+        /// <param name="member">Member being serialized or deserialized.</param>
+        /// <returns>A <see cref="ISerializationConverter"/> which can be used to affect N1QL query generation, or null if none.</returns>
+        /// <remarks>
+        /// Should implement an internal cache for performance, as this method will be
+        /// called repeatedly for the same member.
+        /// </remarks>
+        ISerializationConverter GetSerializationConverter(MemberInfo member);
+    }
+}

--- a/src/Couchbase.EntityFramework/Serialization/ISerializationConverterT.cs
+++ b/src/Couchbase.EntityFramework/Serialization/ISerializationConverterT.cs
@@ -1,0 +1,22 @@
+﻿namespace Couchbase.EntityFramework.Serialization
+{
+    /// <inheritdoc/>
+    public interface ISerializationConverter<T> : ISerializationConverter
+    {
+        /// <summary>
+        /// Noop method call, used as a placeholder for a conversion replicating the
+        /// one being performed during serialization.
+        /// </summary>
+        /// <param name="value">The value to be converted.</param>
+        /// <returns>The value which was converted.</returns>
+        T ConvertTo(T value);
+
+        /// <summary>
+        /// Noop method call, used as a placeholder replicating the inverse of the conversion
+        /// being performed during serialization.
+        /// </summary>
+        /// <param name="value">The value to be converted.</param>
+        /// <returns>The value which was converted.</returns>
+        T ConvertFrom(T value);
+    }
+}

--- a/src/Couchbase.EntityFramework/Serialization/SerializationExpressionTreeProcessor.cs
+++ b/src/Couchbase.EntityFramework/Serialization/SerializationExpressionTreeProcessor.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Linq.Expressions;
+using Couchbase.Core.Serialization;
+using Couchbase.Linq;
+using Couchbase.Linq.Serialization;
+using Remotion.Linq.Parsing.Structure;
+
+namespace Couchbase.EntityFramework.Serialization
+{
+    /// <summary>
+    /// Process the tree to find members which have non-default serialization rules,
+    /// and where present apply conversion expressions.  Internally uses
+    /// <see cref="SerializationExpressionTreeVisitor"/>.
+    /// </summary>
+    internal class SerializationExpressionTreeProcessor : IExpressionTreeProcessor
+    {
+        private readonly ISerializationConverterProvider _serializationConverterProvider;
+
+        public SerializationExpressionTreeProcessor(ISerializationConverterProvider serializationConverterProvider)
+        {
+            _serializationConverterProvider = serializationConverterProvider ??
+                                              throw new ArgumentNullException(nameof(serializationConverterProvider));
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SerializationExpressionTreeProcessor"/> from a <see cref="IBucketContext"/>.
+        /// </summary>
+        /// <param name="bucketContext">The <see cref="IBucketContext"/>.</param>
+        /// <returns>The <see cref="SerializationExpressionTreeProcessor"/>.</returns>
+        public static SerializationExpressionTreeProcessor FromBucketContext(IBucketContext bucketContext)
+        {
+            var serializerProvider = bucketContext.Bucket as ITypeSerializerProvider;
+
+            var serializer = serializerProvider?.Serializer ?? bucketContext.Configuration.Serializer.Invoke();
+
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            return new SerializationExpressionTreeProcessor(
+                serializer as ISerializationConverterProvider ??
+                new DefaultSerializationConverterProvider(serializer));
+        }
+
+        /// <inheritdoc/>
+        public Expression Process(Expression expressionTree)
+        {
+            if (expressionTree == null)
+            {
+                throw new ArgumentNullException(nameof(expressionTree));
+            }
+
+            return new SerializationExpressionTreeVisitor(_serializationConverterProvider).Visit(expressionTree);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Serialization/SerializationExpressionTreeVisitor.cs
+++ b/src/Couchbase.EntityFramework/Serialization/SerializationExpressionTreeVisitor.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.Serialization;
+using Remotion.Linq.Parsing;
+
+namespace Couchbase.Linq.Serialization
+{
+    /// <summary>
+    /// Visits an expression tree, applying <see cref="ISerializationConverter{T}"/> calls when reading or writing
+    /// from members with custom serialization.
+    /// </summary>
+    internal class SerializationExpressionTreeVisitor : RelinqExpressionVisitor
+    {
+        private static readonly HashSet<ExpressionType> ComparisonExpressionTypes = new HashSet<ExpressionType>
+        {
+            ExpressionType.GreaterThan,
+            ExpressionType.GreaterThanOrEqual,
+            ExpressionType.LessThan,
+            ExpressionType.LessThanOrEqual,
+            ExpressionType.Equal,
+            ExpressionType.NotEqual
+        };
+
+        private readonly ISerializationConverterProvider _converterProvider;
+
+        public SerializationExpressionTreeVisitor(ISerializationConverterProvider converterProvider)
+        {
+            _converterProvider = converterProvider ?? throw new ArgumentNullException(nameof(converterProvider));
+        }
+
+        /// <inheritdoc/>
+        /// <summary>
+        /// When getting a property with a serialization converter applied, convert it from the specialized
+        /// storage format to the more standardized format
+        /// </summary>
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            node = node.Update(Visit(node.Expression));
+
+            var converter = _converterProvider.GetSerializationConverter(node.Member);
+            if (converter != null)
+            {
+                return converter.GenerateConvertFromExpression(node);
+            }
+
+            return node;
+        }
+
+        /// <inheritdoc/>
+        /// <summary>
+        /// When assigning values to a property with a custom serializer, such as in a select projection,
+        /// convert them to the custom format in N1QL so they can be correctly deserialized.
+        /// </summary>
+        protected override MemberAssignment VisitMemberAssignment(MemberAssignment node)
+        {
+            var converter = _converterProvider.GetSerializationConverter(node.Member);
+            if (converter != null)
+            {
+                return node.Update(
+                    converter.GenerateConvertToExpression(
+                        Visit(node.Expression)));
+            }
+
+            return base.VisitMemberAssignment(node);
+        }
+
+        /// <inheritdoc/>
+        /// <summary>
+        /// For comparisons, we want to default to comparing in the format already stored in JSON.
+        /// So if one side is a call to ConvertFrom, remove it and place ConvertTo on the other side instead.
+        /// </summary>
+        protected override Expression VisitBinary(BinaryExpression node)
+        {
+            if (!ComparisonExpressionTypes.Contains(node.NodeType))
+            {
+                return base.VisitBinary(node);
+            }
+
+            var left = Visit(node.Left);
+            var right = Visit(node.Right);
+
+            var leftConvertMethod = ExtractConvertFromMethod(left);
+            if (leftConvertMethod != null && !IsNull(right))
+            {
+                var inverseMethod = leftConvertMethod.Method.DeclaringType?.GetMethod("ConvertTo");
+                if (inverseMethod != null)
+                {
+                    return node.Update(
+                        leftConvertMethod.Arguments[0],
+                        node.Conversion,
+                        Expression.Call(
+                            leftConvertMethod.Object,
+                            inverseMethod,
+                            right));
+                }
+            }
+
+            var rightConvertMethod = ExtractConvertFromMethod(right);
+            if (rightConvertMethod != null && !IsNull(left))
+            {
+                var inverseMethod = rightConvertMethod.Method.DeclaringType?.GetMethod("ConvertTo");
+                if (inverseMethod != null)
+                {
+                    return node.Update(
+                        Expression.Call(
+                            rightConvertMethod.Object,
+                            inverseMethod,
+                            left)
+                        ,
+                        node.Conversion,
+                        rightConvertMethod.Arguments[0]);
+                }
+            }
+
+            // Fallback behavior
+            return node.Update(
+                left,
+                node.Conversion,
+                right);
+        }
+
+        private static MethodCallExpression ExtractConvertFromMethod(Expression expression)
+        {
+            if (expression is MethodCallExpression methodCallExpression &&
+                     methodCallExpression.Method.DeclaringType != null)
+            {
+                if (methodCallExpression.Method.DeclaringType.GetTypeInfo().IsInterface &&
+                    methodCallExpression.Method.DeclaringType.GetTypeInfo().IsGenericType &&
+                    methodCallExpression.Method.DeclaringType.GetGenericTypeDefinition() == typeof(ISerializationConverter<>))
+                {
+                    if (methodCallExpression.Method.Name == "ConvertFrom")
+                    {
+                        return methodCallExpression;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static bool IsNull(Expression expression)
+        {
+            return expression is ConstantExpression constantExpression &&
+                   constantExpression.Value == null;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Serialization/TypeBasedSerializationConverterRegistry.cs
+++ b/src/Couchbase.EntityFramework/Serialization/TypeBasedSerializationConverterRegistry.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using Couchbase.Core.Serialization;
+using Couchbase.EntityFramework.Serialization.Converters;
+using Couchbase.Linq.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Couchbase.EntityFramework.Serialization
+{
+    /// <summary>
+    /// Registry of <see cref="JsonConverter"/> types and their corresponding <see cref="ISerializationConverter"/> implementations.
+    /// </summary>
+    public class TypeBasedSerializationConverterRegistry : IJsonNetSerializationConverterRegistry,
+        IEnumerable<KeyValuePair<Type, Type>>
+    {
+        /// <summary>
+        /// Global instance of <see cref="TypeBasedSerializationConverterRegistry"/> which is used
+        /// by default by <see cref="DefaultSerializationConverterProvider"/>.
+        /// Built-in converters are registered by default.
+        /// </summary>
+        public static TypeBasedSerializationConverterRegistry Global { get; } = CreateDefaultRegistry();
+
+        private readonly Dictionary<Type, Type> _registry = new Dictionary<Type, Type>();
+
+        /// <summary>
+        /// Create a new registry loaded with all built in <see cref="ISerializationConverter"/> implementations.
+        /// </summary>
+        /// <returns></returns>
+        public static TypeBasedSerializationConverterRegistry CreateDefaultRegistry() => new TypeBasedSerializationConverterRegistry
+        {
+            { typeof(UnixMillisecondsConverter), typeof(UnixMillisecondsSerializationConverter) },
+            { typeof(StringEnumConverter), typeof(StringEnumSerializationConverter<>)}
+        };
+
+        /// <summary>
+        /// Add an <see cref="ISerializationConverter"/> implementation.
+        /// </summary>
+        /// <param name="jsonConverterType">Type of the <see cref="JsonConverter"/>.</param>
+        /// <param name="serializationConverterType">Type of the <see cref="ISerializationConverter"/> implementation.</param>
+        public void Add(Type jsonConverterType, Type serializationConverterType)
+        {
+            if (jsonConverterType == null)
+            {
+                throw new ArgumentNullException(nameof(jsonConverterType));
+            }
+            if (serializationConverterType == null)
+            {
+                throw new ArgumentNullException(nameof(serializationConverterType));
+            }
+
+            _registry.Add(jsonConverterType, serializationConverterType);
+        }
+
+        /// <summary>
+        /// Remove an <see cref="ISerializationConverter"/> implementation.
+        /// </summary>
+        /// <param name="jsonConverterType">Type of the <see cref="JsonConverter"/>.</param>
+        public void Remove(Type jsonConverterType)
+        {
+            if (jsonConverterType == null)
+            {
+                throw new ArgumentNullException(nameof(jsonConverterType));
+            }
+
+            _registry.Remove(jsonConverterType);
+        }
+
+        /// <inheritdoc/>
+        public ISerializationConverter CreateSerializationConverter(JsonConverter jsonConverter, MemberInfo member)
+        {
+            if (jsonConverter == null)
+            {
+                throw new ArgumentNullException(nameof(jsonConverter));
+            }
+
+            if (_registry.TryGetValue(jsonConverter.GetType(), out var serializationConverterType))
+            {
+                return CreateConverter(serializationConverterType, jsonConverter, member);
+            }
+
+            return null;
+        }
+
+        private ISerializationConverter CreateConverter(Type converterType, JsonConverter jsonConverter,
+            MemberInfo member)
+        {
+            if (converterType.GetTypeInfo().IsGenericTypeDefinition)
+            {
+                var memberType = GetMemberType(member);
+                if (memberType == null)
+                {
+                    throw new NotSupportedException(
+                        "Generic SerializationConverter Applied To A Member Other Than Field Or Property");
+                }
+
+                if (memberType.GetTypeInfo().IsGenericType && memberType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                {
+                    // Extract the inner type if the type is nullable
+                    memberType = memberType.GenericTypeArguments[0];
+                }
+
+                converterType = converterType.MakeGenericType(memberType);
+            }
+
+            var constructor = converterType.GetConstructor(new[] {typeof(JsonConverter), typeof(MemberInfo)});
+            if (constructor != null)
+            {
+                return (ISerializationConverter) constructor.Invoke(new object[] {jsonConverter, member});
+            }
+
+            return (ISerializationConverter) Activator.CreateInstance(converterType);
+        }
+
+        /// <inheritdoc/>
+        public IEnumerator<KeyValuePair<Type, Type>> GetEnumerator()
+        {
+            return _registry.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        private static Type GetMemberType(MemberInfo member)
+        {
+            switch (member)
+            {
+                case FieldInfo field:
+                    return field.FieldType;
+
+                case PropertyInfo property:
+                    return property.PropertyType;
+
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Utils/ExceptionMsgs.cs
+++ b/src/Couchbase.EntityFramework/Utils/ExceptionMsgs.cs
@@ -1,0 +1,43 @@
+﻿namespace Couchbase.EntityFramework.Utils
+{
+    internal class ExceptionMsgs
+    {
+        public const string DocumentNotFound = "Document not found for Id: ";
+
+        public const string KeyAttributeMissing = "No KeyAttribute could be found for the document. Please " +
+                                                  "mark a key property with a KeyAttribute";
+
+        public const string KeyNull = "KeyAttribute marks a property which returned null.  Please " +
+                                      "be sure the key property is non-null.";
+
+        public const string QueryExecutionException = "An error occurred executing the N1QL query.  See the " +
+                                                      "inner exception for details.";
+
+        public const string QueryExecutionUnknownError = "An unknown error occurred executing the N1QL query.";
+
+        public const string QueryExecutionMultipleErrors = "Multiple errors occured executing the N1QL query. " +
+                                                           "See the Errors property for details.";
+    }
+}
+#region [ License information          ]
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2015 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/
+
+#endregion

--- a/src/Couchbase.EntityFramework/Utils/ExcludeSerializationConversionEvaluatableExpressionFilter.cs
+++ b/src/Couchbase.EntityFramework/Utils/ExcludeSerializationConversionEvaluatableExpressionFilter.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq.Expressions;
+using System.Reflection;
+using Couchbase.EntityFramework.Serialization;
+using Remotion.Linq.Parsing.ExpressionVisitors.TreeEvaluation;
+
+namespace Couchbase.EntityFramework.Utils
+{
+    /// <summary>
+    /// Implementation of <see cref="IEvaluatableExpressionFilter"/> which prevents
+    /// pre-evaluation of calls to <see cref="ISerializationConverter{T}"/> methods.
+    /// </summary>
+    internal sealed class ExcludeSerializationConversionEvaluatableExpressionFilter : EvaluatableExpressionFilterBase
+    {
+        public override bool IsEvaluatableMethodCall(MethodCallExpression node)
+        {
+            if (node.Method.DeclaringType != null)
+            {
+                var typeInfo = node.Method.DeclaringType.GetTypeInfo();
+                if (typeInfo.IsInterface && typeInfo.IsGenericType)
+                {
+                    return typeInfo.GetGenericTypeDefinition() != typeof(ISerializationConverter<>);
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Utils/ReflectionUtils.cs
+++ b/src/Couchbase.EntityFramework/Utils/ReflectionUtils.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Couchbase.EntityFramework.Utils
+{
+    internal static class ReflectionUtils
+    {
+        /// <summary>
+        /// Unwraps a conversion to <see cref="Nullable{T}"/>, but only if the
+        /// operand is of the given type <typeparamref name="T"/>.  If the expression
+        /// is already of type <typeparamref name="T"/> it is returned without modification.
+        /// </summary>
+        /// <typeparam name="T">Operand type restriction.  Use <see cref="Expression"/> to unwrap any operand type.</typeparam>
+        /// <param name="expression">Expression to evaluate.</param>
+        /// <param name="wasUnwrapped">True if the expression was unwrapped.</param>
+        /// <returns>
+        /// The unwrapped expression if the expression was a converstion of an operand of type <typeparamref name="T"/>.
+        /// Otherwise, returns the original expression or null if the original expression is not of type <typeparamref name="T"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static T UnwrapNullableConversion<T>(Expression expression, out bool wasUnwrapped)
+            where T: Expression
+        {
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+
+            if (expression is UnaryExpression unaryExpression &&
+                unaryExpression.NodeType == ExpressionType.Convert)
+            {
+                if (unaryExpression.Type.GetTypeInfo().IsGenericType &&
+                    unaryExpression.Type.GetGenericTypeDefinition() == typeof(Nullable<>))
+                {
+                    wasUnwrapped = true;
+                    return unaryExpression.Operand as T;
+                }
+            }
+
+            wasUnwrapped = false;
+            return expression as T;
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Versioning/DefaultVersionProvider.cs
+++ b/src/Couchbase.EntityFramework/Versioning/DefaultVersionProvider.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using Couchbase.Core;
+using Couchbase.Core.Version;
+using Couchbase.Logging;
+
+namespace Couchbase.EntityFramework.Versioning
+{
+    /// <summary>
+    /// Provides the version for a bucket based on the implementationVersion returned by calls
+    /// to http://node-ip:8091/pools.  Caches the results for quick results on future calls.
+    /// </summary>
+    internal class DefaultVersionProvider : IVersionProvider
+    {
+        private readonly ILog _log = LogManager.GetLogger<DefaultVersionProvider>();
+
+        private readonly ConcurrentDictionary<ICluster, ClusterVersion> _versionsByUri =
+            new ConcurrentDictionary<ICluster, ClusterVersion>();
+        private readonly object _lock = new object();
+
+        /// <summary>
+        /// Gets the version of the cluster hosting a bucket.
+        /// </summary>
+        /// <param name="bucket">Couchbase bucket.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="bucket"/> is null.</exception>
+        /// <returns>The version of the cluster hosting this bucket, or 4.0.0 if unable to determine the version.</returns>
+        public ClusterVersion GetVersion(IBucket bucket)
+        {
+            if (bucket == null)
+            {
+                throw new ArgumentNullException("bucket");
+            }
+
+            var cluster = bucket.Cluster;
+
+            // First check for an existing result
+            var version = CacheLookup(cluster);
+            if (version != null)
+            {
+                return version.Value;
+            }
+
+            var contextCache = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(null);
+
+            try
+            {
+                // Only check one cluster at a time, this prevents multiple lookups during bootstrap
+                lock (_lock)
+                {
+                    // In case the version was received while we were waiting for the lock, check for it again
+                    version = CacheLookup(cluster);
+                    if (version != null)
+                    {
+                        return version.Value;
+                    }
+
+                    try
+                    {
+                        // Use the bucket to get the cluster version, in case we're using old-style bucket passwords
+                        version = bucket.GetClusterVersionAsync().Result;
+
+                        if (version != null)
+                        {
+                            CacheStore(cluster, version.Value);
+                            return version.Value;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _log.Error("Unhandled error getting cluster version", ex);
+
+                        // Don't cache on exception, but assume 4.0 for now
+                        return new ClusterVersion(new Version(4, 0, 0));
+                    }
+
+                    // No version information could be loaded from any node
+                    var fallbackVersion = new ClusterVersion(new Version(4, 0, 0));
+                    CacheStore(cluster, fallbackVersion);
+                    return fallbackVersion;
+                }
+            }
+            finally
+            {
+                if (contextCache != null)
+                {
+                    SynchronizationContext.SetSynchronizationContext(contextCache);
+                }
+            }
+        }
+
+        internal virtual ClusterVersion? CacheLookup(ICluster cluster)
+        {
+            if (_versionsByUri.TryGetValue(cluster, out var version))
+            {
+                return version;
+            }
+
+            return null;
+        }
+
+        internal virtual void CacheStore(ICluster cluster, ClusterVersion version)
+        {
+            _versionsByUri.AddOrUpdate(cluster, version, (key, oldValue) => version);
+        }
+    }
+}

--- a/src/Couchbase.EntityFramework/Versioning/FeatureVersions.cs
+++ b/src/Couchbase.EntityFramework/Versioning/FeatureVersions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Couchbase.Core.Version;
+
+namespace Couchbase.EntityFramework.Versioning
+{
+    /// <summary>
+    /// Constants for the Couchbase versions where new features are implemented.
+    /// </summary>
+    internal static class FeatureVersions
+    {
+        /// <summary>
+        /// Version where support was added for index-based joins where the primary key for the join
+        /// is on the left instead of the right.
+        /// </summary>
+        public static readonly ClusterVersion IndexJoin = new ClusterVersion(new Version(4, 5, 0));
+
+        /// <summary>
+        /// Version where support was added for full ANSI joins.
+        /// </summary>
+        public static readonly ClusterVersion AnsiJoin = new ClusterVersion(new Version(5, 5, 0));
+
+        /// <summary>
+        /// Version where support was added for RYOW consistency.
+        /// </summary>
+        public static readonly ClusterVersion ReadYourOwnWrite = new ClusterVersion(new Version(4, 5, 0));
+
+        /// <summary>
+        /// Version where support was added for array indexes.
+        /// </summary>
+        public static readonly ClusterVersion ArrayIndexes = new ClusterVersion(new Version(4, 5, 0));
+
+        /// <summary>
+        /// Version where support was added for SELECT RAW
+        /// </summary>
+        public static readonly ClusterVersion SelectRaw = new ClusterVersion(new Version(5, 0, 0));
+
+        /// <summary>
+        /// Version where support was added for SELECT ... FROM queries on arrays
+        /// </summary>
+        public static readonly ClusterVersion ArrayInFromClause = new ClusterVersion(new Version(5, 0, 0));
+    }
+}

--- a/src/Couchbase.EntityFramework/Versioning/IVersionProvider.cs
+++ b/src/Couchbase.EntityFramework/Versioning/IVersionProvider.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Couchbase.Core;
+using Couchbase.Core.Version;
+
+namespace Couchbase.EntityFramework.Versioning
+{
+    /// <summary>
+    /// Provides the Couchbase version for a bucket.
+    /// </summary>
+    internal interface IVersionProvider
+    {
+        /// <summary>
+        /// Gets the version of the cluster hosting a bucket.
+        /// </summary>
+        /// <param name="bucket">Couchbase bucket.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="bucket"/> is null.</exception>
+        /// <returns>The version of the cluster hosting this bucket, or 4.0.0 if unable to determine the version.</returns>
+        ClusterVersion GetVersion(IBucket bucket);
+    }
+}

--- a/src/Couchbase.EntityFramework/Versioning/VersionProvider.cs
+++ b/src/Couchbase.EntityFramework/Versioning/VersionProvider.cs
@@ -1,0 +1,18 @@
+﻿namespace Couchbase.EntityFramework.Versioning
+{
+    /// <summary>
+    /// Singleton for the <see cref="IVersionProvider"/> implementation in use for query generation.
+    /// </summary>
+    internal static class VersionProvider
+    {
+        /// <summary>
+        /// Singleton for the <see cref="IVersionProvider"/> implementation in use for query generation.
+        /// </summary>
+        public static IVersionProvider Current { get; set; }
+
+        static VersionProvider()
+        {
+            Current = new DefaultVersionProvider();
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
Ports over the ReLinq portion of Linq2Couchbase in hopes of reusing the
query API in Couchbase EF v1.

Modifications
-------------
 - Move over most query related stuff (and some other stuff to make it
build).
 - Rename all to Couchbase.EntityFramework* namespaces.

Result
------
Builds, but needs to be pruned of various things that EF provides and
implements differently.