### PR TITLE
Remove Couchbase.Linq namespace references

### DIFF
--- a/src/Couchbase.EntityFramework/BucketQueryOptions.cs
+++ b/src/Couchbase.EntityFramework/BucketQueryOptions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Couchbase.EntityFramework.Filters;
-using Couchbase.Linq;
 
 namespace Couchbase.EntityFramework
 {

--- a/src/Couchbase.EntityFramework/CouchbaseConsistencyException.cs
+++ b/src/Couchbase.EntityFramework/CouchbaseConsistencyException.cs
@@ -1,6 +1,4 @@
-﻿using Couchbase.Linq;
-
-namespace Couchbase.EntityFramework
+﻿namespace Couchbase.EntityFramework
 {
     /// <summary>
     /// Thrown if a write operation fails because the document has been modified since it was read.

--- a/src/Couchbase.EntityFramework/Extensions/EnumerableExtensions.cs
+++ b/src/Couchbase.EntityFramework/Extensions/EnumerableExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Couchbase.EntityFramework.Metadata;
-using Couchbase.Linq;
 
 namespace Couchbase.EntityFramework.Extensions
 {

--- a/src/Couchbase.EntityFramework/IBucketContext.cs
+++ b/src/Couchbase.EntityFramework/IBucketContext.cs
@@ -2,7 +2,6 @@
 using Couchbase.Configuration.Client;
 using Couchbase.Core;
 using Couchbase.EntityFramework.Extensions;
-using Couchbase.Linq;
 using Couchbase.N1QL;
 
 namespace Couchbase.EntityFramework

--- a/src/Couchbase.EntityFramework/Metadata/IDocumentMetadataProvider.cs
+++ b/src/Couchbase.EntityFramework/Metadata/IDocumentMetadataProvider.cs
@@ -1,6 +1,4 @@
-﻿using Couchbase.Linq;
-
-namespace Couchbase.EntityFramework.Metadata
+﻿namespace Couchbase.EntityFramework.Metadata
 {
     /// <summary>
     /// Returns metadata about the document object the interface is attached to

--- a/src/Couchbase.EntityFramework/N1QlDatePart.cs
+++ b/src/Couchbase.EntityFramework/N1QlDatePart.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.Serialization;
-using Couchbase.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/src/Couchbase.EntityFramework/N1QlFunctions.Metadata.cs
+++ b/src/Couchbase.EntityFramework/N1QlFunctions.Metadata.cs
@@ -16,15 +16,12 @@ namespace Couchbase.EntityFramework
             // using LINQ-to-Objects and faking a Couchbase database
             // Any faked document object should implement IDocumentMetadataProvider
 
-            var provider = document as IDocumentMetadataProvider;
-            if (provider != null)
+            if (document is IDocumentMetadataProvider provider)
             {
                 return provider.GetMetadata();
             }
-            else
-            {
-                return null;
-            }
+
+            return null;
         }
 
         /// <summary>
@@ -39,17 +36,14 @@ namespace Couchbase.EntityFramework
             // using LINQ-to-Objects and faking a Couchbase database
             // Any faked document object should implement IDocumentMetadataProvider
 
-            var provider = document as IDocumentMetadataProvider;
-            if (provider != null)
+            if (document is IDocumentMetadataProvider provider)
             {
                 var metadata = provider.GetMetadata();
 
-                return metadata != null ? metadata.Id : null;
+                return metadata?.Id;
             }
-            else
-            {
-                return null;
-            }
+
+            return null;
         }
     }
 }

--- a/src/Couchbase.EntityFramework/Proxies/DocumentProxyDataMapper.cs
+++ b/src/Couchbase.EntityFramework/Proxies/DocumentProxyDataMapper.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using Couchbase.Configuration.Client;
 using Couchbase.Core.Serialization;
-using Couchbase.Linq;
 using Couchbase.Views;
 
 namespace Couchbase.EntityFramework.Proxies

--- a/src/Couchbase.EntityFramework/Proxies/DocumentProxyTypeCreator.cs
+++ b/src/Couchbase.EntityFramework/Proxies/DocumentProxyTypeCreator.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Couchbase.Core.Serialization;
-using Couchbase.Linq;
 
 namespace Couchbase.EntityFramework.Proxies
 {

--- a/src/Couchbase.EntityFramework/QueryGeneration/ExpressionTransformers/DateTimeComparisonExpressionTransformer.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/ExpressionTransformers/DateTimeComparisonExpressionTransformer.cs
@@ -6,7 +6,6 @@ using System.Reflection;
 using Couchbase.EntityFramework.QueryGeneration.MethodCallTranslators;
 using Couchbase.EntityFramework.Serialization;
 using Couchbase.EntityFramework.Serialization.Converters;
-using Couchbase.Linq.Serialization;
 using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
 
 namespace Couchbase.EntityFramework.QueryGeneration.ExpressionTransformers

--- a/src/Couchbase.EntityFramework/QueryGeneration/LinqQueryRequest.cs
+++ b/src/Couchbase.EntityFramework/QueryGeneration/LinqQueryRequest.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Couchbase.EntityFramework.Execution;
-using Couchbase.Linq;
 using Couchbase.N1QL;
 using Remotion.Linq.Parsing.ExpressionVisitors;
 

--- a/src/Couchbase.EntityFramework/Serialization/Converters/SerializationConverterBase.cs
+++ b/src/Couchbase.EntityFramework/Serialization/Converters/SerializationConverterBase.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Couchbase.EntityFramework.QueryGeneration;
-using Couchbase.Linq.Serialization;
 
 namespace Couchbase.EntityFramework.Serialization.Converters
 {

--- a/src/Couchbase.EntityFramework/Serialization/Converters/StringEnumSerializationConverter.cs
+++ b/src/Couchbase.EntityFramework/Serialization/Converters/StringEnumSerializationConverter.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using Couchbase.EntityFramework.QueryGeneration;
-using Couchbase.Linq.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/Couchbase.EntityFramework/Serialization/Converters/UnixMillisecondsSerializationConverter.cs
+++ b/src/Couchbase.EntityFramework/Serialization/Converters/UnixMillisecondsSerializationConverter.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using Couchbase.EntityFramework.QueryGeneration;
-using Couchbase.Linq.Serialization;
 
 namespace Couchbase.EntityFramework.Serialization.Converters
 {

--- a/src/Couchbase.EntityFramework/Serialization/DefaultSerializationConverterProvider.cs
+++ b/src/Couchbase.EntityFramework/Serialization/DefaultSerializationConverterProvider.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Couchbase.Core.Serialization;
-using Couchbase.Linq.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Couchbase.EntityFramework/Serialization/ISerializationConverter.cs
+++ b/src/Couchbase.EntityFramework/Serialization/ISerializationConverter.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq.Expressions;
 using Couchbase.EntityFramework.QueryGeneration;
-using Couchbase.Linq.Serialization;
 
 namespace Couchbase.EntityFramework.Serialization
 {

--- a/src/Couchbase.EntityFramework/Serialization/SerializationExpressionTreeProcessor.cs
+++ b/src/Couchbase.EntityFramework/Serialization/SerializationExpressionTreeProcessor.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq.Expressions;
 using Couchbase.Core.Serialization;
-using Couchbase.Linq;
 using Couchbase.Linq.Serialization;
 using Remotion.Linq.Parsing.Structure;
 

--- a/src/Couchbase.EntityFramework/Serialization/TypeBasedSerializationConverterRegistry.cs
+++ b/src/Couchbase.EntityFramework/Serialization/TypeBasedSerializationConverterRegistry.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Reflection;
 using Couchbase.Core.Serialization;
 using Couchbase.EntityFramework.Serialization.Converters;
-using Couchbase.Linq.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 


### PR DESCRIPTION
Motivation
----------
Removes references (using) to Couchbase.Linq namespace - the namespaces
have been changed to Couchbase.EntityFramework.

Modifications
-------------
Remove using statements for Couchbase.Linq.

Result
------
Couchbase.Linq using statements have been removed from the project.